### PR TITLE
fix(core): 🐛 emit performed layout event during perform layout is wrong

### DIFF
--- a/core/src/context/layout_context.rs
+++ b/core/src/context/layout_context.rs
@@ -10,6 +10,7 @@ use crate::prelude::{widget_tree::WidgetTree, BoxClamp, WidgetId};
 pub struct LayoutCtx<'a> {
   pub(crate) id: WidgetId,
   pub(crate) tree: &'a mut WidgetTree,
+  pub(crate) performed: &'a mut Vec<WidgetId>,
 }
 
 impl<'a> LayoutCtx<'a> {
@@ -32,7 +33,7 @@ impl<'a> LayoutCtx<'a> {
   /// Do the work of computing the layout for render child, and return its size
   /// it should have. Should called from parent.
   pub fn perform_child_layout(&mut self, child: WidgetId, clamp: BoxClamp) -> Size {
-    child.perform_layout(clamp, self.tree)
+    child.perform_layout(clamp, self.tree, self.performed)
   }
 
   /// Return a tuple of [`LayoutCtx`]! and an iterator of `id`'s children.

--- a/core/src/widget/layout/layout_box.rs
+++ b/core/src/widget/layout/layout_box.rs
@@ -20,25 +20,55 @@ impl ComposeSingleChild for LayoutBox {
   }
 }
 
+impl LayoutBox {
+  #[inline]
+  pub fn box_rect(&self) -> Rect { self.rect }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{prelude::Window, test::root_and_children_rect};
+  use crate::test::{expect_layout_result, ExpectRect, LayoutTestItem};
 
   #[test]
   fn smoke() {
-    let w = widget! {
-      Row {
-        LayoutBox {
-          id: layout_box,
-          SizedBox { size: Size::new(100., 200.) }
+    expect_layout_result(
+      Size::new(500., 500.),
+      widget! {
+        Row {
+          LayoutBox {
+            id: layout_box,
+            SizedBox { size: Size::new(100., 200.) }
+          }
+          SizedBox { size: layout_box.rect.size }
         }
-        SizedBox { size: layout_box.rect.size }
-      }
-    };
-    let mut wnd = Window::wgpu_headless(w, DeviceSize::new(500, 500));
-    wnd.draw_frame();
-    let (rect, _) = root_and_children_rect(&wnd);
-    assert_eq!(rect.size, Size::new(200., 200.));
+      },
+      &[
+        LayoutTestItem {
+          path: &[0],
+          expect: ExpectRect {
+            width: Some(200.),
+            height: Some(200.),
+            ..<_>::default()
+          },
+        },
+        LayoutTestItem {
+          path: &[0, 0],
+          expect: ExpectRect {
+            width: Some(100.),
+            height: Some(200.),
+            ..<_>::default()
+          },
+        },
+        LayoutTestItem {
+          path: &[0, 1],
+          expect: ExpectRect {
+            width: Some(100.),
+            height: Some(200.),
+            ..<_>::default()
+          },
+        },
+      ],
+    );
   }
 }

--- a/core/src/widget/layout/widget_children.rs
+++ b/core/src/widget/layout/widget_children.rs
@@ -336,17 +336,3 @@ impl MultiChildMarker<GenMulti> for ExprWidget<GenMulti> {
     multi.children.push(w)
   }
 }
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  #[test]
-  fn fix_stateful_compose_single_have_child() {
-    let _ = ScrollableWidget {
-      scrollable: Scrollable::Both,
-      pos: Point::zero(),
-    }
-    .into_stateful()
-    .have_child(Void);
-  }
-}

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -108,10 +108,13 @@ impl Window {
       } = self;
 
       context.borrow_mut().begin_frame();
-      let struct_dirty = widget_tree.any_struct_dirty();
+      let mut struct_dirty = false;
 
-      widget_tree.tree_repair();
-      widget_tree.layout(raw_window.inner_size());
+      while widget_tree.is_dirty() {
+        struct_dirty |= widget_tree.any_struct_dirty();
+        widget_tree.tree_repair();
+        widget_tree.layout(raw_window.inner_size());
+      }
       if struct_dirty {
         dispatcher.refresh_focus(widget_tree);
       }

--- a/widget_derive/src/widget_attr_macro/dataflows.rs
+++ b/widget_derive/src/widget_attr_macro/dataflows.rs
@@ -25,7 +25,7 @@ mod ct {
 
 pub struct Dataflows {
   _dataflows_token: kw::dataflows,
-  brace_token: token::Brace,
+  _brace_token: token::Brace,
   flows: Punctuated<Dataflow, token::Comma>,
 }
 
@@ -42,7 +42,7 @@ impl Parse for Dataflows {
     let content;
     Ok(Self {
       _dataflows_token: input.parse()?,
-      brace_token: braced!(content in input),
+      _brace_token: braced!(content in input),
       flows: Punctuated::parse_terminated(&content)?,
     })
   }
@@ -50,9 +50,7 @@ impl Parse for Dataflows {
 
 impl ToTokens for Dataflows {
   fn to_tokens(&self, tokens: &mut TokenStream) {
-    self.brace_token.surround(tokens, |tokens| {
-      self.flows.iter().for_each(|t| t.to_tokens(tokens));
-    });
+    self.flows.iter().for_each(|t| t.to_tokens(tokens));
   }
 }
 
@@ -88,10 +86,10 @@ impl ToTokens for Dataflow {
     let capture_tokens = captures.into_iter().into_iter().map(capture_widget);
 
     let subscribe_do = skip_nc_assign(self.skip_nc.is_some(), &to.expr, &from.expr);
-    tokens.extend(quote! {
+    tokens.extend(quote! {{
       #(#capture_tokens)*
       #upstream.subscribe(move |_| { #(#refs_tokens)* #subscribe_do });
-    });
+    }});
   }
 }
 

--- a/widget_derive/tests/ui/declare/data_flow_syntax_pass.rs
+++ b/widget_derive/tests/ui/declare/data_flow_syntax_pass.rs
@@ -14,6 +14,7 @@ fn main() {
     }
     dataflows { a.size ~> b.size }
   };
+
   let _data_flow_embed = widget! {
     Flex {
       SizedBox {
@@ -37,5 +38,17 @@ fn main() {
       }
     }
     dataflows { a.size ~> b.size }
+  };
+
+  let _fix_named_obj_moved_in_data_flow = widget! {
+    Flex {
+      SizedBox { id: a, size: Size::zero() }
+      SizedBox { id: b, size: Size::zero() }
+      SizedBox { id: c, size: Size::zero() }
+    }
+    dataflows {
+      a.size ~> b.size,
+      a.size ~> c.size
+    }
   };
 }


### PR DESCRIPTION
Because stateful widget emit event alredy in borrowed, and the the
handle access it will always crash.