### PR TITLE
refactor(compiler): 💡 immediately release borrow of `StateRef` when u…

### DIFF
--- a/core/src/context/build_context.rs
+++ b/core/src/context/build_context.rs
@@ -51,24 +51,18 @@ mod tests {
   #[test]
   #[should_panic(expected = "Get a default theme from context")]
   fn always_have_default_theme() {
-    struct T;
-    impl Compose for T {
-      fn compose(_: StateWidget<Self>) -> Widget {
-        widget! {
-          ExprWidget {
-            expr: {
-              let _ = ctx.theme();
-              panic!("Get a default theme from context");
-              #[allow(unreachable_code)]
-              Void {}
-            }
-          }
+    let w = widget! {
+      ExprWidget {
+        expr: {
+          let _ = ctx.theme();
+          panic!("Get a default theme from context");
+          #[allow(unreachable_code)]
+          Void {}
         }
       }
-    }
-
+    };
     // should panic when construct widget tree
-    WidgetTree::new(T.into_widget(), <_>::default());
+    WidgetTree::new(w, <_>::default());
   }
 
   #[derive(Debug, Declare)]

--- a/core/src/widget/stateful.rs
+++ b/core/src/widget/stateful.rs
@@ -278,6 +278,9 @@ impl<'a, W> StateRef<'a, W> {
   {
     *self
   }
+
+  #[inline]
+  pub fn release_current_borrow(&mut self) { self.0.release_current_borrow(); }
 }
 
 impl<'a, W> std::ops::Deref for SilentRef<'a, W> {

--- a/widget_derive/src/widget_attr_macro.rs
+++ b/widget_derive/src/widget_attr_macro.rs
@@ -95,13 +95,6 @@ impl Id {
   }
 }
 
-fn obj_state_ref(widget: &Ident) -> TokenStream2 {
-  quote_spanned!(widget.span() =>
-    #[allow(unused_mut)]
-    let mut #widget = #widget.state_ref();
-  )
-}
-
 fn capture_widget(widget: &Ident) -> TokenStream2 {
   quote_spanned!(widget.span() => let #widget = #widget.clone_stateful();)
 }


### PR DESCRIPTION
…se finished

we depends on state reference to track data change, and notify change when ref drop, if many ref mut accessed, the first ref notify during others borrowing, that may easy to occur borrow crash. This commit ensure release all borrow before notify.