### PR TITLE
fix(macros): 🐛 support access named builtin accross `silent` and `sha…

### DIFF
--- a/core/examples/animation_demo.rs
+++ b/core/examples/animation_demo.rs
@@ -29,7 +29,6 @@ fn main() {
         duration: Duration::from_secs(5),
         easing: easing::EASE_IN_OUT,
       }
-      // .delay(Duration::from_secs(1)),
     }
   };
 

--- a/macros/src/widget_macro/parser.rs
+++ b/macros/src/widget_macro/parser.rs
@@ -608,8 +608,10 @@ impl ToTokens for AnimateState {
     let target_value = self.maybe_tuple_value(|StateField { path, .. }| {
       quote! { #path.clone()}
     });
+
     let target_assign = self.maybe_tuple_value(|StateField { path, .. }| {
-      quote! { #path }
+      let MemberPath { widget, dot, member } = path;
+      quote! { #widget #dot shallow() #dot #member }
     });
 
     let v = ribir_variable("v", state_span);

--- a/macros/tests/declare_test.rs
+++ b/macros/tests/declare_test.rs
@@ -300,3 +300,17 @@ fn fix_builtin_field_can_declare_as_widget() {
   let wnd = Window::without_render(w, Size::zero());
   assert_eq!(wnd.widget_count(), 2);
 }
+
+#[test]
+fn fix_access_builtin_with_gap() {
+  widget! {
+    Void {
+      id: this,
+      cursor: CursorIcon::Hand,
+      tap: move |e| {
+        // this access cursor across `silent` or `shallow` should compile pass.
+        let _ = this.shallow().cursor == this.silent().cursor;
+      }
+    }
+  };
+}


### PR DESCRIPTION
…dllow`