### PR TITLE
Fix link

### DIFF
--- a/docs/custom_widget_declare_in_macro.md
+++ b/docs/custom_widget_declare_in_macro.md
@@ -122,8 +122,8 @@ let _ = widget!{
 
 There are two other `meta` that we don't use in `HeroCard`, but need to know about.
 
-- We can use `#[declare(skip)]` to skip the field that we don't want the user to declare. The field type must implement the `Default` trait or provide a default expression through the `default` meta.
-- We can use `#[declare(rename=...)]` to rename a field. It's useful if our field name conflicts with the built-in fields. See [all built-in fields](builtin_fields).
+- We can use #[declare(skip)] to skip the field that we don't want the user to declare. The field type must implement the `Default` trait or provide a default expression through the `default` meta.
+- We can use #[declare(rename=...)] to rename a field. It's useful if our field name conflicts with the built-in fields. See [builtin fields].
 
- [declare_derive]: ../ribir/widget_derive/Declare.html
- [builtin_fields]: ../ribir/widget_derive/declare_builtin_fields.html
+ [declare_derive]: ./Declare.html
+ [builtin fields]: builtin_widget/declare_builtin_fields.md


### PR DESCRIPTION
The link to `declare_builtin_fields.md` was broken in several ways.  Is GitHub markdown the intended target or is there another environment (like `crates.io`, ...) with other requirements this links were intented to render in?

I haven't found what file the other link (`declare_derive`) was intended to link to.   It's broken as well. Perhaps the content is now inlined in `custom_widget_declar_in_macro.md` (this file, that contains the link)