### PR TITLE
fix(macros): 🐛 closure should also watch the states modifies.

### DIFF
--- a/core/src/declare.rs
+++ b/core/src/declare.rs
@@ -54,11 +54,11 @@ mod tests {
 
 /// struct help the generate code have better type hint.
 #[derive(Clone)]
-pub struct DeclareFieldValue<F: Clone>(F);
+pub struct DeclareFieldValue<F>(F);
 
-impl<R, F: Clone> DeclareFieldValue<F>
+impl<R, F> DeclareFieldValue<F>
 where
-  F: Clone + FnMut() -> R,
+  F: FnMut() -> R,
 {
   #[inline]
   pub fn new(f: F) -> Self { Self(f) }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -29,7 +29,7 @@ ribir_painter = {path = "../painter", version = "0.0.0"}
 smallvec = "1.8.0"
 
 [dev-dependencies]
-# ribir = {path = "../ribir", version = "*"}
+ribir = {path = "../ribir", version = "0.0.0"}
 trybuild = "1.0.77"
 winit = "0.28.1"
 

--- a/macros/src/widget_macro/name_used_info.rs
+++ b/macros/src/widget_macro/name_used_info.rs
@@ -157,7 +157,7 @@ impl ScopeUsedInfo {
       if names.clone().nth(1).is_some() {
         quote! {let _guard = (#(#names.modify_guard(),)*);}.to_tokens(tokens);
       }
-      c_names.clone().for_each(|n| {
+      c_names.for_each(|n| {
         quote_spanned! {n.span() => let mut #n = #n.state_ref();}.to_tokens(tokens);
       });
     }

--- a/ribir/examples/todo_mvp.rs
+++ b/ribir/examples/todo_mvp.rs
@@ -93,7 +93,7 @@ impl TodoMVP {
                 .enumerate()
                 .filter(move |(_, task)| { cond(task) })
                 .map(move |(idx, task)| {
-                  Self::task(this, task, idx, mount_task_cnt)
+                  no_watch!(Self::task(this, task, idx, mount_task_cnt))
                 })
             }
           }

--- a/widgets/src/lists.rs
+++ b/widgets/src/lists.rs
@@ -72,37 +72,21 @@ impl ComposeChild for ListItem {
         let body_text_style = TypographyTheme::of(ctx).body1.text.clone();
       }
       Row {
-        DynWidget {
-          dyns: leading.map(|w| w.child)
-        }
+        Option::map(leading, |w| w.child)
         Expanded {
           flex: 1.,
           Column {
-            DynWidget {
-              dyns: widget! {
-                Text {
-                  text: headline_text.0,
-                  style: TextStyle {
-                    foreground: surface_variant,
-                    ..body_text_style
-                  }
-                }
+            Text {
+              text: headline_text.0,
+              style: TextStyle {
+                foreground: surface_variant,
+                ..body_text_style
               }
             }
-            DynWidget {
-              dyns: supporting_text.map(|text| {
-                widget! {
-                  Text {
-                    text: text.0
-                  }
-                }
-              })
-            }
+            Option::map(supporting_text, |text | widget! { Text { text: text.0 } })
           }
         }
-        DynWidget {
-          dyns: trailing.map(|w| w.child)
-        }
+        Option::map(trailing, |w| w.child)
       }
     }
   }
@@ -133,10 +117,7 @@ impl ComposeChild for Lists {
               ListItemStyle {
                 divider: this.divider,
                 edge,
-
-                DynWidget {
-                  dyns: w
-                }
+                identify(w)
               }
             }
           })

--- a/widgets/src/tabs.rs
+++ b/widgets/src/tabs.rs
@@ -102,17 +102,12 @@ impl ComposeChild for Tabs {
                           padding: EdgeInsets::vertical(6.),
                           h_align: HAlign::Center,
                           dyns: {
-                            if this.cur_idx == idx {
-                              Text {
-                                text: text.0.clone(),
-                                style: active_text_style,
-                              }
+                            let style =  if this.cur_idx == idx {
+                              active_text_style.clone()
                             } else {
-                              Text {
-                                text: text.0.clone(),
-                                style: normal_text_style,
-                              }
-                            }
+                              normal_text_style.clone()
+                            };
+                            Text { text: text.0.clone(), style }
                           }
                         }
                       }


### PR DESCRIPTION
We do not watch anything in the closure body before, but it's not correct if the user defines a closure and calls it in the next line. For example:

```
widget! {
  states { outside_state }
  Text {
    text: {
      let c = move || outside_state.get_text();
      x()
    }
  }
}
```
This example does not watch `outside_state`, It's wrong.

This fix will also watch the closure body, but remove the watch only if the closure is a field value directly.

#227 was merged in a mistake