### PR TITLE
fix(macros): 🐛 embed states variable can not be directly used

### DIFF
--- a/macros/src/widget_macro/visit_mut.rs
+++ b/macros/src/widget_macro/visit_mut.rs
@@ -66,6 +66,7 @@ pub struct LocalVariable {
 }
 
 impl LocalVariable {
+  pub fn new(name: Ident, alias: Ident) -> Self { Self { name, alias_of_name: Some(alias) } }
   pub fn local(name: Ident) -> Self { Self { name, alias_of_name: None } }
 }
 

--- a/macros/tests/code_gen_test.rs
+++ b/macros/tests/code_gen_test.rs
@@ -467,3 +467,16 @@ fn no_watch() {
   wnd.draw_frame();
   assert_layout_result(&wnd, &[0], &ExpectRect::from_size(ZERO_SIZE));
 }
+
+#[test]
+fn embed_shadow_states() {
+  let _ = widget! {
+    // variable `_a` here
+    identify(|_a: &BuildCtx| widget! {
+      // states shadow `a`
+      states { _a: Stateful::new(ZERO_SIZE) }
+      // `_a` should be the state `_a`
+      SizedBox { size: *_a }
+    })
+  };
+}


### PR DESCRIPTION
embed states variable can not be directly used if the outside variable has the same name