### PR TITLE
fix(text): 🐛 inline offset should depends on font size

### DIFF
--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -164,7 +164,9 @@ impl Default for FontFace {
   }
 }
 
-/// Horizontal Alignment
+/// Text-align relative to the horizontal or vertical, not caring about whether
+/// the text is left-to-right or right-to-left, In the horizontal the left is
+/// the start, and in vertical the top is the start.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum TextAlign {
   Start,


### PR DESCRIPTION
This pr only fixes the chars not placed in the center with a line height. And some bugs leave that the typography store does not consider, vertical line and rtl. 

- we should refactor the typography man with an abstract axis and implement a convertor that converts the axis from the abstract axis to the visual axis.