### PR TITLE
Feat/option widget

### DIFF
--- a/core/src/animation/transition.rs
+++ b/core/src/animation/transition.rs
@@ -1,10 +1,6 @@
-use crate::prelude::*;
-
-use crate::prelude::BuildCtx;
-
 use super::easing::Easing;
-use std::rc::Rc;
-use std::time::Duration;
+use crate::prelude::{BuildCtx, *};
+use std::{ops::Deref, rc::Rc, time::Duration};
 
 /// Transition describe how the state change form init to final smoothly.
 #[derive(Declare, Clone, Debug, PartialEq)]

--- a/core/src/builtin_widgets/delay_drop_widget.rs
+++ b/core/src/builtin_widgets/delay_drop_widget.rs
@@ -1,4 +1,4 @@
-use crate::{impl_query_self_only, prelude::*};
+use crate::{impl_query_self_only, prelude::*, widget::TreeArena};
 
 #[derive(Declare)]
 pub struct DelayDropWidget {

--- a/core/src/builtin_widgets/focus_scope.rs
+++ b/core/src/builtin_widgets/focus_scope.rs
@@ -1,6 +1,7 @@
-use crate::events::focus_mgr::FocusType;
-use crate::{context::LayoutCtx, widget::BoxClamp};
-use crate::{impl_query_self_only, prelude::*};
+use crate::{
+  context::LayoutCtx, events::focus_mgr::FocusType, impl_query_self_only, prelude::*,
+  widget::BoxClamp,
+};
 
 #[derive(Declare, Clone, Default)]
 pub struct FocusScope {

--- a/core/src/builtin_widgets/lifecycle.rs
+++ b/core/src/builtin_widgets/lifecycle.rs
@@ -196,16 +196,14 @@ mod tests {
         on_mounted: move |_| lifecycle.silent().push("static mounted"),
         on_performed_layout: move |_| lifecycle.silent().push("static performed layout"),
         on_disposed: move |_| lifecycle.silent().push("static disposed"),
-        DynWidget {
-          dyns: trigger.then(|| widget! {
-            MockBox {
-              size: Size::zero(),
-              on_mounted: move |_| lifecycle.silent().push("dyn mounted"),
-              on_performed_layout: move |_| lifecycle.silent().push("dyn performed layout"),
-              on_disposed: move |_| lifecycle.silent().push("dyn disposed")
-            }
-          })
-        }
+        widget::then(*trigger, || widget! {
+          MockBox {
+            size: Size::zero(),
+            on_mounted: move |_| lifecycle.silent().push("dyn mounted"),
+            on_performed_layout: move |_| lifecycle.silent().push("dyn performed layout"),
+            on_disposed: move |_| lifecycle.silent().push("dyn disposed")
+          }
+        })
       }
     };
 

--- a/core/src/builtin_widgets/transform_widget.rs
+++ b/core/src/builtin_widgets/transform_widget.rs
@@ -1,4 +1,4 @@
-use crate::{impl_query_self_only, prelude::*};
+use crate::{impl_query_self_only, prelude::*, widget::hit_test_impl};
 
 #[derive(SingleChild, Declare, Clone)]
 pub struct TransformWidget {

--- a/core/src/context/build_context.rs
+++ b/core/src/context/build_context.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use std::{
   cell::{Ref, RefCell},
+  ops::Deref,
   rc::Rc,
 };
 

--- a/core/src/context/widget_context.rs
+++ b/core/src/context/widget_context.rs
@@ -189,7 +189,7 @@ impl<'a> LifeCycleCtx<'a> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{prelude::*, test::MockBox};
+  use crate::{prelude::*, test::MockBox, widget::WidgetTree};
 
   define_widget_context!(TestCtx);
 

--- a/core/src/enum_widget.rs
+++ b/core/src/enum_widget.rs
@@ -1,7 +1,7 @@
 //! Implements a dozen of enums to store different widget, and implement the
 //! common trait if all enum variable implement it.
 
-use crate::prelude::*;
+use crate::prelude::{widget::ImplMarker, *};
 
 macro_rules! impl_enum_widget {
   ($name: ident, $($var_ty: ident, $mark_ty: ident) ,+ ) => {

--- a/core/src/events/focus_mgr.rs
+++ b/core/src/events/focus_mgr.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, widget_tree::TreeArena};
+use crate::{prelude::*, widget::WidgetTree, widget_tree::TreeArena};
 
 use indextree::{Arena, NodeId};
 use std::{

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,10 @@ pub mod prelude {
   #[doc(no_inline)]
   pub use crate::widget;
   #[doc(no_inline)]
-  pub use crate::widget::*;
+  pub use crate::widget::{
+    Any, Compose, HitTest, IntoWidget, NotSelf, OptionWidget, Query, QueryFiler, QueryOrder,
+    Render, SelfImpl, TypeId, Widget,
+  };
   #[doc(no_inline)]
   pub use crate::widget_children::*;
   #[doc(no_inline)]

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -415,3 +415,30 @@ impl Query for Box<dyn Render> {
 impl Query for Vec<SubscriptionGuard<BoxSubscription<'static>>> {
   impl_query_self_only!();
 }
+
+/// Optional widget.
+pub struct OptionWidget<W>(pub(crate) Option<W>);
+
+/// Directly return `v`, this function does nothing, but it's useful to help you
+/// declare a widget expression in `widget!` macro.
+#[inline]
+pub const fn from<W>(v: W) -> W { v }
+
+/// Return OptionWidget::Some widget if the `b` is true, the return value wrap
+/// from the return value of `f` method called.
+#[inline]
+pub fn then<W>(b: bool, f: impl FnOnce() -> W) -> OptionWidget<W> { OptionWidget(b.then(f)) }
+
+/// Returns [`OptionWidget::None`] if the w is [`None`], otherwise wrapped the
+/// widget with `OptionWidget` and returns:
+#[inline]
+pub fn filter<W>(w: Option<W>) -> OptionWidget<W> { OptionWidget(w) }
+
+/// calls the closure on `value` and returns
+#[inline]
+pub fn map<T, W>(value: T, f: impl FnOnce(T) -> W) -> W { f(value) }
+
+/// Do both filter and map
+pub fn filter_map<T, W>(w: Option<T>, f: impl FnOnce(T) -> W) -> OptionWidget<W> {
+  OptionWidget(w.map(f))
+}

--- a/core/src/widget_children/compose_child_impl.rs
+++ b/core/src/widget_children/compose_child_impl.rs
@@ -94,15 +94,6 @@ mod with_target_child {
     fn into_target_child(self) -> Widget { self.into_widget() }
   }
 
-  impl<D, M> IntoTargetChild<NotSelf<[M; 1]>, Widget> for Stateful<DynWidget<Option<D>>>
-  where
-    D: IntoWidget<M> + 'static,
-    M: ImplMarker,
-  {
-    #[inline]
-    fn into_target_child(self) -> Widget { self.into_widget() }
-  }
-
   impl<T, C> IntoTargetChild<NotSelf<[(); 2]>, State<C>> for T
   where
     T: Into<State<C>>,
@@ -365,7 +356,6 @@ mod with_child_template {
   }
 
   impl_fill_widget!(C, 0);
-  impl_fill_widget!(Stateful<DynWidget<Option<C>>>, 1, 'static);
 
   macro_rules! impl_fill_tml_for_state {
     ($name: ty, $idx:tt $(,$static:lifetime)?) => {
@@ -445,7 +435,6 @@ mod with_child_template {
     };
   }
   impl_fill_pair_widget!(C, 11);
-  impl_fill_pair_widget!(Stateful<DynWidget<Option<C>>>, 12, 'static);
 
   impl<T, C> FillTml<NotSelf<[(); 13]>, C> for T
   where

--- a/core/src/widget_children/multi_child_impl.rs
+++ b/core/src/widget_children/multi_child_impl.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::widget::ImplMarker;
 
 /// Trait specify what child a multi child widget can have, and the target type
 /// after widget compose its child.

--- a/core/src/widget_children/single_child_impl.rs
+++ b/core/src/widget_children/single_child_impl.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::widget::ImplMarker;
 
 /// Trait specify what child a widget can have, and the target type is the
 /// result of widget compose its child.

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -1,5 +1,5 @@
 use indextree::*;
-use std::{cell::RefCell, collections::HashSet, rc::Rc};
+use std::{cell::RefCell, collections::HashSet, ops::Deref, rc::Rc};
 
 pub mod widget_id;
 pub(crate) use widget_id::TreeArena;
@@ -369,16 +369,12 @@ mod tests {
     let child = Stateful::new(true);
     let w = widget! {
       states { parent: parent.clone(), child: child.clone() }
-      DynWidget {
-        dyns: parent.then(|| {
-          widget!{
-            MockBox {
-              size: Size::zero(),
-              DynWidget { dyns: child.then(|| Void )}
-            }
-          }
-        })
-      }
+      widget::then(*parent, || widget!{
+        MockBox {
+          size: Size::zero(),
+          widget::then(*child, || Void)
+        }
+      })
     };
 
     let mut wnd = Window::default_mock(w, None);
@@ -398,11 +394,9 @@ mod tests {
     let trigger = Stateful::new(true);
     let w = widget! {
       states { trigger: trigger.clone() }
-      DynWidget {
-        dyns: trigger.then(|| {
-          widget!{ DynWidget { dyns: trigger.then(|| Void )}}
-        })
-      }
+      widget::then(*trigger, || widget!{
+        widget::then(*trigger, || Void)
+      })
     };
 
     let mut wnd = Window::default_mock(w, None);

--- a/tests/code_gen_test.rs
+++ b/tests/code_gen_test.rs
@@ -365,16 +365,12 @@ fn fix_subscribe_cancel_after_widget_drop() {
     states { cnt: notify_cnt.clone(), trigger: trigger.clone() }
     SizedBox {
       size: Size::zero(),
-      DynWidget  {
-        dyns: trigger.then(|| {
-          widget! {
-            SizedBox { size: Size::zero() }
-            finally {
-              let_watch!(*trigger.deref()).subscribe(move |_| *cnt +=1 );
-            }
-          }
-        })
-      }
+      widget::then(*trigger, || widget! {
+        SizedBox { size: Size::zero() }
+        finally {
+          let_watch!(*trigger).subscribe(move |_| *cnt +=1 );
+        }
+      })
     }
   };
 

--- a/tests/compile_message.rs
+++ b/tests/compile_message.rs
@@ -3,8 +3,8 @@ use ribir::prelude::{include_svg, SvgPaths};
 #[test]
 fn compile_msg() {
   let t = trybuild::TestCases::new();
-  t.compile_fail("tests/compile_msg/**/*fail.rs");
-  t.pass("tests/compile_msg/**/*pass.rs");
+  t.compile_fail("./compile_msg/**/*fail.rs");
+  t.pass("./compile_msg/**/*pass.rs");
 }
 
 #[test]

--- a/tests/compile_msg/declare/circular_dependency_fail.stderr
+++ b/tests/compile_msg/declare/circular_dependency_fail.stderr
@@ -1,5 +1,5 @@
 error: There is a directly circle depends exist, this will cause infinite loop: id3.size ~> id1 , id2.size ~> id3 , id1.size ~> id2
-  --> tests/ui/declare/circular_dependency_fail.rs:7:13
+  --> compile_msg/declare/circular_dependency_fail.rs:7:13
    |
 7  |         id: id1,
    |             ^^^
@@ -24,7 +24,7 @@ note: You should manual watch expression and add operator to break the circular,
           .debounce(Duration::ZERO, ctx.wnd_ctx().frame_scheduler())
           .subscribe(...)
       ```
-  --> tests/ui/declare/circular_dependency_fail.rs:8:9
+  --> compile_msg/declare/circular_dependency_fail.rs:8:9
    |
 8  |         size: id2.size,
    |         ^^^^
@@ -36,7 +36,7 @@ note: You should manual watch expression and add operator to break the circular,
    |         ^^^^
 
 error: There is a directly circle depends exist, this will cause infinite loop: parent.margin ~> child , child.margin ~> parent
-  --> tests/ui/declare/circular_dependency_fail.rs:23:11
+  --> compile_msg/declare/circular_dependency_fail.rs:23:11
    |
 23 |       id: parent,
    |           ^^^^^^
@@ -58,7 +58,7 @@ note: You should manual watch expression and add operator to break the circular,
           .debounce(Duration::ZERO, ctx.wnd_ctx().frame_scheduler())
           .subscribe(...)
       ```
-  --> tests/ui/declare/circular_dependency_fail.rs:25:7
+  --> compile_msg/declare/circular_dependency_fail.rs:25:7
    |
 25 |       margin: child.margin.clone(),
    |       ^^^^^^

--- a/tests/compile_msg/declare/ctx_only_allow_in_init_and_finally_fail.stderr
+++ b/tests/compile_msg/declare/ctx_only_allow_in_init_and_finally_fail.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `ctx` in this scope
-  --> tests/ui/declare/ctx_only_allow_in_init_and_finally_fail.rs:31:48
+  --> compile_msg/declare/ctx_only_allow_in_init_and_finally_fail.rs:31:48
    |
 31 |       size: ZERO_SIZE, background: Palette::of(ctx).primary()
    |                                                ^^^ not found in this scope

--- a/tests/compile_msg/declare/duplicate_id_fail.stderr
+++ b/tests/compile_msg/declare/duplicate_id_fail.stderr
@@ -1,5 +1,5 @@
 error: Same `id: same_id` assign to multiple objects, id must be unique.
- --> tests/ui/declare/duplicate_id_fail.rs:6:11
+ --> compile_msg/declare/duplicate_id_fail.rs:6:11
   |
 6 |       id: same_id,
   |           ^^^^^^^
@@ -8,7 +8,7 @@ error: Same `id: same_id` assign to multiple objects, id must be unique.
   |             ^^^^^^^
 
 error: Same `id: same_id` assign to multiple objects, id must be unique.
-  --> tests/ui/declare/duplicate_id_fail.rs:16:14
+  --> compile_msg/declare/duplicate_id_fail.rs:16:14
    |
 16 |     states { same_id: Stateful::new(0) }
    |              ^^^^^^^
@@ -17,7 +17,7 @@ error: Same `id: same_id` assign to multiple objects, id must be unique.
    |           ^^^^^^^
 
 error: Same `id: same_id` assign to multiple objects, id must be unique.
-  --> tests/ui/declare/duplicate_id_fail.rs:25:11
+  --> compile_msg/declare/duplicate_id_fail.rs:25:11
    |
 25 |       id: same_id,
    |           ^^^^^^^
@@ -26,7 +26,7 @@ error: Same `id: same_id` assign to multiple objects, id must be unique.
    |                          ^^^^^^^
 
 error: Same `id: same_id` assign to multiple objects, id must be unique.
-  --> tests/ui/declare/duplicate_id_fail.rs:36:14
+  --> compile_msg/declare/duplicate_id_fail.rs:36:14
    |
 36 |     states { same_id: Stateful::new(0),}
    |              ^^^^^^^
@@ -35,7 +35,7 @@ error: Same `id: same_id` assign to multiple objects, id must be unique.
    |                        ^^^^^^^
 
 error: Same `id: same_id` assign to multiple objects, id must be unique.
-  --> tests/ui/declare/duplicate_id_fail.rs:45:14
+  --> compile_msg/declare/duplicate_id_fail.rs:45:14
    |
 45 |     states { same_id: Stateful::new(0),}
    |              ^^^^^^^
@@ -44,7 +44,7 @@ error: Same `id: same_id` assign to multiple objects, id must be unique.
    |                  ^^^^^^^
 
 error: Same `id: same_id` assign to multiple objects, id must be unique.
-  --> tests/ui/declare/duplicate_id_fail.rs:56:11
+  --> compile_msg/declare/duplicate_id_fail.rs:56:11
    |
 56 |       id: same_id,
    |           ^^^^^^^

--- a/tests/compile_msg/declare/fix_attr_indirect_follow_host_fail.stderr
+++ b/tests/compile_msg/declare/fix_attr_indirect_follow_host_fail.stderr
@@ -1,5 +1,5 @@
 error: There is a directly circle depends exist, this will cause infinite loop: b.cursor ~> a , a.cursor ~> b
-  --> tests/ui/declare/fix_attr_indirect_follow_host_fail.rs:23:11
+  --> compile_msg/declare/fix_attr_indirect_follow_host_fail.rs:23:11
    |
 23 |       id: a,
    |           ^
@@ -21,7 +21,7 @@ note: You should manual watch expression and add operator to break the circular,
           .debounce(Duration::ZERO, ctx.wnd_ctx().frame_scheduler())
           .subscribe(...)
       ```
-  --> tests/ui/declare/fix_attr_indirect_follow_host_fail.rs:25:7
+  --> compile_msg/declare/fix_attr_indirect_follow_host_fail.rs:25:7
    |
 25 |       cursor: b.cursor,
    |       ^^^^^^

--- a/tests/compile_msg/declare/let_watch_desugar_syntax_fail.stderr
+++ b/tests/compile_msg/declare/let_watch_desugar_syntax_fail.stderr
@@ -1,5 +1,5 @@
 error: expected `;`
- --> tests/ui/declare/let_watch_desugar_syntax_fail.rs:7:7
+ --> compile_msg/declare/let_watch_desugar_syntax_fail.rs:7:7
   |
 7 |       let_watch!(sized_box.size).subscribe(|_| {})
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/compile_msg/declare/unused_warning_fail.stderr
+++ b/tests/compile_msg/declare/unused_warning_fail.stderr
@@ -1,17 +1,17 @@
 error: Test for declare syntax warning.
- --> tests/ui/declare/unused_warning_fail.rs:4:3
+ --> compile_msg/declare/unused_warning_fail.rs:4:3
   |
 4 |   compile_error!("Test for declare syntax warning.");
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: assigned id but not be used in anywhere.
- --> tests/ui/declare/unused_warning_fail.rs:7:11
+ --> compile_msg/declare/unused_warning_fail.rs:7:11
   |
 7 |       id: test_id,
   |           ^^^^^^^
   |
 help: Remove this line.
- --> tests/ui/declare/unused_warning_fail.rs:7:11
+ --> compile_msg/declare/unused_warning_fail.rs:7:11
   |
 7 |       id: test_id,
   |           ^^^^^^^

--- a/tests/compile_msg/declare/widget_before_field_fail.stderr
+++ b/tests/compile_msg/declare/widget_before_field_fail.stderr
@@ -1,5 +1,5 @@
 error: Field should always declare before children.
- --> tests/ui/declare/widget_before_field_fail.rs:8:7
+ --> compile_msg/declare/widget_before_field_fail.rs:8:7
   |
 8 |       size
   |       ^^^^

--- a/tests/compile_msg/declare_builder_fail.stderr
+++ b/tests/compile_msg/declare_builder_fail.stderr
@@ -1,5 +1,5 @@
 error: the identify `margin` is reserved to expand space around widget wrapped.
- --> tests/ui/declare_builder_fail.rs:5:3
+ --> compile_msg/declare_builder_fail.rs:5:3
   |
 5 |   margin: i32,
   |   ^^^^^^

--- a/widgets/src/text_field.rs
+++ b/widgets/src/text_field.rs
@@ -5,8 +5,7 @@ use crate::{
   prelude::{Expanded, Icon, Input, Label, Row, Stack, Text},
 };
 use ribir_core::prelude::*;
-use std::collections::HashMap;
-use std::hash::Hash;
+use std::{collections::HashMap, hash::Hash, ops::Deref};
 
 #[derive(Declare, Default)]
 pub struct TextField {


### PR DESCRIPTION
Add `OptionWidget` and not support `Option` as a widget type, this can reduce the complexity of our widget child convert logic, which the child converts logic refactor will do in the future.

Add functions `widget::then`, `widget::map`, `widget::filter` and `widget::filter_map` so we can more conveniently declare an expression as a widget in `widget!` macro.