### PR TITLE
feat(core): 🎸 support capture

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -27,7 +27,7 @@ use self::dispatcher::DispatchInfo;
 pub struct EventCommon {
   pub(crate) target: WidgetId,
   pub(crate) current_target: WidgetId,
-  pub(crate) cancel_bubble: bool,
+  pub(crate) is_propagation: bool,
   pub(crate) prevent_default: bool,
   tree: NonNull<WidgetTree>,
   info: NonNull<DispatchInfo>,
@@ -47,14 +47,15 @@ impl EventCommon {
   pub fn current_target(&self) -> WidgetId { self.current_target }
   /// Prevent event bubbling to parent.
   #[inline]
-  pub fn stop_bubbling(&mut self) { self.cancel_bubble = true }
+  pub fn stop_propagation(&mut self) { self.is_propagation = true }
   /// Return it the event is canceled to bubble to parent.
   #[inline]
-  pub fn bubbling_canceled(&self) -> bool { self.cancel_bubble }
+  pub fn is_propagation(&self) -> bool { self.is_propagation }
   /// Tells the user agent that if the event does not get explicitly handled,
   /// its default action should not be taken as it normally would be.
   #[inline]
   pub fn prevent_default(&mut self) { self.prevent_default = true; }
+
   /// Represents the current state of the keyboard modifiers
   #[inline]
   pub fn modifiers(&self) -> ModifiersState { self.dispatch_info().modifiers() }
@@ -149,7 +150,7 @@ impl std::fmt::Debug for EventCommon {
     f.debug_struct("CommonEvent")
       .field("target", &self.target)
       .field("current_target", &self.current_target)
-      .field("cancel_bubble", &self.cancel_bubble)
+      .field("is_propagation", &self.is_propagation)
       .finish()
   }
 }
@@ -159,7 +160,7 @@ impl EventCommon {
     Self {
       target,
       current_target: target,
-      cancel_bubble: <_>::default(),
+      is_propagation: <_>::default(),
       prevent_default: <_>::default(),
       tree: NonNull::from(tree),
       info: NonNull::from(info),

--- a/core/src/events/focus.rs
+++ b/core/src/events/focus.rs
@@ -1,8 +1,9 @@
 use std::convert::Infallible;
 
 use crate::{
-  data_widget::compose_child_as_data_widget, impl_compose_child_for_listener,
-  impl_compose_child_with_focus_for_listener, impl_listener, impl_query_self_only, prelude::*,
+  impl_compose_child_for_listener, impl_compose_child_with_focus_for_listener, impl_listener,
+  impl_listener_and_compose_child, impl_listener_and_compose_child_with_focus,
+  impl_query_self_only, prelude::*,
 };
 
 pub type FocusEvent = EventCommon;
@@ -35,6 +36,12 @@ pub struct FocusInListener {
 }
 
 #[derive(Declare)]
+pub struct FocusInCaptureListener {
+  #[declare(builtin, convert=custom)]
+  on_focus_in_capture: MutRefItemSubject<'static, FocusEvent, Infallible>,
+}
+
+#[derive(Declare)]
 pub struct FocusOutListener {
   /// The focusout event fires when an widget is about to lose focus. The main
   /// difference between this event and blur is that focusout bubbles while blur
@@ -43,38 +50,56 @@ pub struct FocusOutListener {
   on_focus_out: MutRefItemSubject<'static, FocusEvent, Infallible>,
 }
 
-impl_listener!(
+#[derive(Declare)]
+pub struct FocusOutCaptureListener {
+  #[declare(builtin, convert=custom)]
+  on_focus_out_capture: MutRefItemSubject<'static, FocusEvent, Infallible>,
+}
+
+impl_listener_and_compose_child_with_focus!(
   FocusListener,
   FocusListenerDeclarer,
   on_focus,
   FocusEvent,
   focus_stream
 );
-impl_compose_child_with_focus_for_listener!(FocusListener);
 
-impl_listener!(
+impl_listener_and_compose_child_with_focus!(
   BlurListener,
   BlurListenerDeclarer,
   on_blur,
   FocusEvent,
   blur_stream
 );
-impl_compose_child_with_focus_for_listener!(BlurListener);
 
-impl_listener!(
+impl_listener_and_compose_child!(
   FocusInListener,
   FocusInListenerDeclarer,
   on_focus_in,
   FocusEvent,
   focus_in_stream
 );
-impl_compose_child_for_listener!(FocusInListener);
 
-impl_listener!(
+impl_listener_and_compose_child!(
+  FocusInCaptureListener,
+  FocusInCaptureListenerDeclarer,
+  on_focus_in_capture,
+  FocusEvent,
+  focus_in_capture_stream
+);
+
+impl_listener_and_compose_child!(
   FocusOutListener,
   FocusOutListenerDeclarer,
   on_focus_out,
   FocusEvent,
   focus_out_stream
 );
-impl_compose_child_for_listener!(FocusOutListener);
+
+impl_listener_and_compose_child!(
+  FocusOutCaptureListener,
+  FocusOutCaptureListenerDeclarer,
+  on_focus_out_capture,
+  FocusEvent,
+  focus_out_capture_stream
+);

--- a/core/src/events/focus_mgr.rs
+++ b/core/src/events/focus_mgr.rs
@@ -501,9 +501,17 @@ impl Dispatcher {
       .find(|wid| !(*wid).is_dropped(&tree.arena))
     {
       let mut focus_event = FocusEvent::new(*wid, tree, info);
+      tree.capture_event_with(
+        &mut focus_event,
+        |focus_out_capture: &FocusOutCaptureListener, event| {
+          if !common_ancestors.contains(&event.current_target()) {
+            focus_out_capture.dispatch(event);
+          }
+        },
+      );
       tree.bubble_event_with(&mut focus_event, |focus_out: &FocusOutListener, event| {
         if common_ancestors.contains(&event.current_target()) {
-          event.stop_bubbling();
+          event.stop_propagation();
         } else {
           focus_out.dispatch(event);
         }
@@ -520,11 +528,18 @@ impl Dispatcher {
         });
 
       let mut focus_event = FocusEvent::new(wid, tree, info);
-
+      tree.capture_event_with(
+        &mut focus_event,
+        |focus_in_capture: &FocusInCaptureListener, event| {
+          if !common_ancestors.contains(&event.current_target()) {
+            focus_in_capture.dispatch(event);
+          }
+        },
+      );
       // bubble focus in
       tree.bubble_event_with(&mut focus_event, |focus_in: &FocusInListener, event| {
         if common_ancestors.contains(&event.current_target()) {
-          event.stop_bubbling();
+          event.stop_propagation();
         } else {
           focus_in.dispatch(event);
         }

--- a/core/src/events/listener_impl_helper.rs
+++ b/core/src/events/listener_impl_helper.rs
@@ -55,3 +55,19 @@ macro_rules! impl_compose_child_with_focus_for_listener {
     }
   };
 }
+
+#[macro_export]
+macro_rules! impl_listener_and_compose_child {
+  ($listener:ident, $declarer: ident, $field: ident, $event_ty: ident, $stream_name: ident) => {
+    impl_listener!($listener, $declarer, $field, $event_ty, $stream_name);
+    impl_compose_child_for_listener!($listener);
+  };
+}
+
+#[macro_export]
+macro_rules! impl_listener_and_compose_child_with_focus {
+  ($listener:ident, $declarer: ident, $field: ident, $event_ty: ident, $stream_name: ident) => {
+    impl_listener!($listener, $declarer, $field, $event_ty, $stream_name);
+    impl_compose_child_with_focus_for_listener!($listener);
+  };
+}

--- a/docs/builtin_widget/declare_builtin_fields.md
+++ b/docs/builtin_widget/declare_builtin_fields.md
@@ -3,21 +3,35 @@
 - on_performed_layout : [`Box < dyn for < 'r > FnMut(LifeCycleCtx < 'r >) >`] 
  	 - action perform after widget performed layout.
 - performed_layout_stream : [`LifecycleSubject`] 
- 	 - return an observable stream of the performed layout event
+ 	 - return an observable stream of the performed layout event.
 - on_pointer_down : [`impl FnMut(& mut PointerEvent)`] 
- 	 - specify the event handler for the pointer down event.
+ 	 - specify the event handler for the pointer down event in bubble phase.
+- on_pointer_down_capture : [`impl FnMut(& mut PointerEvent)`] 
+ 	 - specify the event handler for the pointer down event in capture phase.
 - on_pointer_up : [`impl FnMut(& mut PointerEvent)`] 
- 	 - specify the event handler for the pointer up event.
+ 	 - specify the event handler for the pointer up event in bubble phase.
+- on_pointer_up_capture : [`impl FnMut(& mut PointerEvent)`] 
+ 	 - specify the event handler for the pointer up event in capture phase.
 - on_pointer_move : [`impl FnMut(& mut PointerEvent)`] 
- 	 - specify the event handler for the pointer move event.
+ 	 - specify the event handler for the pointer move event in bubble phase.
+- on_pointer_move_capture : [`impl FnMut(& mut PointerEvent)`] 
+ 	 - specify the event handler for the pointer move event in capture phase.
 - on_tap : [`impl FnMut(& mut PointerEvent)`] 
- 	 - specify the event handler for the pointer tap event.
+ 	 - specify the event handler for the pointer tap event in bubble phase.
 - on_double_tap : [`Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >`] 
- 	 - specify the event handler for the pointer double tap event.
-- on_tripe_tap : [`Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >`] 
- 	 - specify the event handler for the pointer triple tap event.
+ 	 - specify the event handler for the pointer double tap event in bubble phase.
+- on_triple_tap : [`Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >`] 
+ 	 - specify the event handler for the pointer triple tap event in bubble phase.
 - on_x_times_tap : [`(usize, Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >)`] 
- 	 - specify the event handler for the pointer `x` times tap event.
+ 	 - specify the event handler for the pointer `x` times tap event in bubble phase.
+- on_tap_capture : [`impl FnMut(& mut PointerEvent)`] 
+ 	 - specify the event handler for the pointer tap event in capture phase.
+- on_double_tap_capture : [`Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >`] 
+ 	 - specify the event handler for the pointer double tap event in capture phase.
+- on_triple_tap_capture : [`Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >`] 
+ 	 - specify the event handler for the pointer triple tap event in capture phase.
+- on_x_times_tap_capture : [`(usize, Box < dyn for < 'r > FnMut(& 'r mut PointerEvent) >)`] 
+ 	 - specify the event handler for the pointer `x` times tap event in capture phase.
 - on_pointer_cancel : [`impl FnMut(& mut PointerEvent)`] 
  	 - specify the event handler to process pointer cancel event.
 - on_pointer_enter : [`impl FnMut(& mut PointerEvent)`] 
@@ -33,17 +47,29 @@
 - on_blur : [`impl FnMut(& mut FocusEvent)`] 
  	 - specify the event handler to process blur event.
 - on_focus_in : [`impl FnMut(& mut FocusEvent)`] 
- 	 - specify the event handler to process focusin event.
+ 	 - specify the event handler to process focusin event in bubble phase.
+- on_focus_in_capture : [`impl FnMut(& mut FocusEvent)`] 
+ 	 - specify the event handler to process focusin event in capture phase.
 - on_focus_out : [`impl FnMut(& mut FocusEvent)`] 
- 	 - specify the event handler to process focusout event.
+ 	 - specify the event handler to process focusout event in bubble phase.
+- on_focus_out_capture : [`impl FnMut(& mut FocusEvent)`] 
+ 	 - specify the event handler to process focusout event in capture phase.
 - on_key_down : [`impl FnMut(& mut KeyboardEvent)`] 
- 	 - specify the event handler when keyboard press down.
+ 	 - specify the event handler when keyboard press down in bubble phase.
+- on_key_down_capture : [`impl FnMut(& mut KeyboardEvent)`] 
+ 	 - specify the event handler when keyboard press down in capture phase.
 - on_key_up : [`impl FnMut(& mut KeyboardEvent)`] 
- 	 - specify the event handler when a key is released.
+ 	 - specify the event handler when a key is released in bubble phase.
+- on_key_up_capture : [`impl FnMut(& mut KeyboardEvent)`] 
+ 	 - specify the event handler when a key is released in capture phase.
 - on_chars : [`impl FnMut(& mut CharsEvent)`] 
- 	 - specify the event handler when received unicode characters.
+ 	 - specify the event handler when received unicode characters in bubble phase.
+- on_chars_capture : [`impl FnMut(& mut CharsEvent)`] 
+ 	 - specify the event handler when received unicode characters in capture phase.
 - on_wheel : [`impl FnMut(& mut WheelEvent)`] 
- 	 - specify the event handler when user moving a mouse wheel or similar input device.
+ 	 - specify the event handler when user moving a mouse wheel or similar input device in bubble phase.
+- on_wheel_capture : [`impl FnMut(& mut WheelEvent)`] 
+ 	 - specify the event handler when user moving a mouse wheel or similar input device in capture phase.
 - box_fit : [`BoxFit`] 
  	 -  set how its child should be resized to its box.
 - background : [`Brush`] 
@@ -93,34 +119,66 @@
 
  - `fn pointer_down_stream(& self) -> MutRefItemSubject < 'static, PointerEvent,
 () >`
- 	- return an observable stream of the pointer down event
+ 	- return an observable stream of the pointer down event in bubble phase.
+
+ - `fn pointer_down_capture_stream(& self) -> MutRefItemSubject < 'static,
+PointerEvent, () >`
+ 	- return an observable stream of the pointer down event in capture phase.
 
  - `fn pointer_up_stream(& self) -> MutRefItemSubject < 'static, PointerEvent, ()
 >`
- 	- return an observable stream of the pointer up event
+ 	- return an observable stream of the pointer up event in bubble phase.
+
+ - `fn pointer_up_capture_stream(& self) -> MutRefItemSubject < 'static,
+PointerEvent, () >`
+ 	- return an observable stream of the pointer up event in capture phase.
 
  - `fn pointer_move_stream(& self) -> MutRefItemSubject < 'static, PointerEvent,
 () >`
- 	- return an observable stream of the pointer move event
+ 	- return an observable stream of the pointer move event in bubble phase.
+
+ - `fn pointer_move_capture_stream(& self) -> MutRefItemSubject < 'static,
+PointerEvent, () >`
+ 	- return an observable stream of the pointer move event in bubble phase.
 
  - `fn tap_stream(& self) -> MutRefItemSubject < 'static, PointerEvent, () >`
- 	- return an observable stream of the pointer tap event
+ 	- return an observable stream of the pointer tap event in bubble phase.
 
  - `fn double_tap_stream(& self,) -> FilterMapOp < MutRefItemSubject < 'static,
 PointerEvent, () >, impl FnMut(& mut PointerEvent) -> Option < & mut
 PointerEvent >, & mut PointerEvent, >`
- 	-  Return an observable stream of double tap event
+ 	-  Return an observable stream of double tap event in bubble phase.
 
  - `fn triple_tap_stream(& self,) -> FilterMapOp < MutRefItemSubject < 'static,
 PointerEvent, () >, impl FnMut(& mut PointerEvent) -> Option < & mut
 PointerEvent >, & mut PointerEvent, >`
- 	- Return an observable stream of tripe tap event
+ 	- Return an observable stream of tripe tap event in bubble phase.
 
  - `fn x_times_tap_stream(& self, x : usize, dur : Duration,) -> FilterMapOp <
 MutRefItemSubject < 'static, PointerEvent, () >, impl
 FnMut(& mut PointerEvent) -> Option < & mut PointerEvent >, & mut
 PointerEvent, >`
- 	-  Return an observable stream of x-tap event that user tapped 'x' times in the specify duration `dur`.
+ 	-  Return an observable stream of x-tap event that user tapped 'x' times in the specify duration `dur` in bubble phase.
+
+ - `fn tap_capture_stream(& self) -> MutRefItemSubject < 'static, PointerEvent, ()
+>`
+ 	- return an observable stream of the pointer tap event in capture phase.
+
+ - `fn double_tap_capture_stream(& self,) -> FilterMapOp < MutRefItemSubject <
+'static, PointerEvent, () >, impl FnMut(& mut PointerEvent) -> Option < & mut
+PointerEvent >, & mut PointerEvent, >`
+ 	- return an observable stream of double tap event in capture phase.
+
+ - `fn triple_tap_capture_stream(& self,) -> FilterMapOp < MutRefItemSubject <
+'static, PointerEvent, () >, impl FnMut(& mut PointerEvent) -> Option < & mut
+PointerEvent >, & mut PointerEvent, >`
+ 	- Return an observable stream of tripe tap event in capture phase.
+
+ - `fn x_times_tap_capture_stream(& self, x : usize, dur : Duration,) ->
+FilterMapOp < MutRefItemSubject < 'static, PointerEvent, () >, impl
+FnMut(& mut PointerEvent) -> Option < & mut PointerEvent >, & mut
+PointerEvent, >`
+ 	-  Return an observable stream of x-tap event that user tapped 'x' times in the specify duration `dur` in capture phase.
 
  - `fn pointer_cancel_stream(& self) -> MutRefItemSubject < 'static, PointerEvent,
 () >`
@@ -147,25 +205,49 @@ PointerEvent, >`
  	- return an observable stream of the pointer blur event
 
  - `fn focus_in_stream(& self) -> MutRefItemSubject < 'static, FocusEvent, () >`
- 	- return an observable stream of the pointer focus-in event
+ 	- return an observable stream of the pointer focus-in event in bubble phase.
+
+ - `fn focus_in_capture_stream(& self) -> MutRefItemSubject < 'static, FocusEvent,
+() >`
+ 	- return an observable stream of the pointer focus-in event in capture phase.
 
  - `fn focus_out_stream(& self) -> MutRefItemSubject < 'static, FocusEvent, () >`
- 	- return an observable stream of the pointer focus-out event
+ 	- return an observable stream of the pointer focus-out event in bubble phase.
+
+ - `fn focus_out_capture_stream(& self) -> MutRefItemSubject < 'static,
+FocusEvent, () >`
+ 	- return an observable stream of the pointer focus-out event in capture phase.
 
  - `fn has_focus(& self) -> bool`
  	- return if the widget has focus.
 
  - `fn key_down_stream(& self) -> MutRefItemSubject < 'static, KeyboardEvent, () >`
- 	- return an observable stream of the key down event
+ 	- return an observable stream of the key down event in bubble phase.
+
+ - `fn key_down_capture_stream(& self) -> MutRefItemSubject < 'static,
+KeyboardEvent, () >`
+ 	- return an observable stream of the key down event in capture phase.
 
  - `fn key_up_stream(& self) -> MutRefItemSubject < 'static, KeyboardEvent, () >`
- 	- return an observable stream of the key up event
+ 	- return an observable stream of the key up event in bubble phase.
+
+ - `fn key_up_capture_stream(& self) -> MutRefItemSubject < 'static,
+KeyboardEvent, () >`
+ 	- return an observable stream of the key up event in capture phase.
 
  - `fn chars_stream(& self) -> MutRefItemSubject < 'static, CharsEvent, () >`
- 	- return an observable stream of the char event
+ 	- return an observable stream of the chars event in bubble phase.
+
+ - `fn chars_capture_stream(& self) -> MutRefItemSubject < 'static, CharsEvent, ()
+>`
+ 	- return an observable stream of the chars event in capture phase.
 
  - `fn key_down_stream(& self) -> MutRefItemSubject < 'static, WheelEvent, () >`
- 	- return an observable stream of the wheel event
+ 	- return an observable stream of the wheel event in bubble phase.
+
+ - `fn wheel_capture_stream(& self) -> MutRefItemSubject < 'static, WheelEvent, ()
+>`
+ 	- return an observable stream of the wheel event in capture phase.
 
  - `fn mouse_hover(& self) -> bool`
  	- return if the pointer is hover on the widget

--- a/macros/src/builtin_fields_list.rs
+++ b/macros/src/builtin_fields_list.rs
@@ -2,45 +2,66 @@ builtin! {
   PerformedLayoutListener {
     #[doc="action perform after widget performed layout."]
     on_performed_layout: Box<dyn for<'r> FnMut(LifeCycleCtx<'r>)>,
-    #[doc= "return an observable stream of the performed layout event"]
+    #[doc= "return an observable stream of the performed layout event."]
     performed_layout_stream: LifecycleSubject,
   }
 
   PointerDownListener {
-    #[doc="specify the event handler for the pointer down event."]
+    #[doc="specify the event handler for the pointer down event in bubble phase."]
     on_pointer_down: impl FnMut(&mut PointerEvent),
-    #[doc= "return an observable stream of the pointer down event"]
+    #[doc="return an observable stream of the pointer down event in bubble phase."]
     fn pointer_down_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
   }
 
+  PointerDownCaptureListener {
+    #[doc="specify the event handler for the pointer down event in capture phase."]
+    on_pointer_down_capture: impl FnMut(&mut PointerEvent),
+    #[doc="return an observable stream of the pointer down event in capture phase."]
+    fn pointer_down_capture_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
+  }
+
   PointerUpListener {
-    #[doc="specify the event handler for the pointer up event."]
+    #[doc="specify the event handler for the pointer up event in bubble phase."]
     on_pointer_up: impl FnMut(&mut PointerEvent),
-    #[doc= "return an observable stream of the pointer up event"]
+    #[doc="return an observable stream of the pointer up event in bubble phase."]
     fn pointer_up_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
   }
 
+  PointerUpCaptureListener {
+    #[doc="specify the event handler for the pointer up event in capture phase."]
+    on_pointer_up_capture: impl FnMut(&mut PointerEvent),
+    #[doc="return an observable stream of the pointer up event in capture phase."]
+    fn pointer_up_capture_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
+  }
+
   PointerMoveListener {
-    #[doc="specify the event handler for the pointer move event."]
+    #[doc="specify the event handler for the pointer move event in bubble phase."]
     on_pointer_move: impl FnMut(&mut PointerEvent),
-    #[doc= "return an observable stream of the pointer move event"]
+    #[doc="return an observable stream of the pointer move event in bubble phase."]
     fn pointer_move_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
   }
 
+  PointerMoveCaptureListener {
+    #[doc="specify the event handler for the pointer move event in capture phase."]
+    on_pointer_move_capture: impl FnMut(&mut PointerEvent),
+    #[doc="return an observable stream of the pointer move event in bubble phase."]
+    fn pointer_move_capture_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
+  }
+
   TapListener {
-    #[doc="specify the event handler for the pointer tap event."]
+    #[doc="specify the event handler for the pointer tap event in bubble phase."]
     on_tap: impl FnMut(&mut PointerEvent),
-    #[doc="specify the event handler for the pointer double tap event."]
+    #[doc="specify the event handler for the pointer double tap event in bubble phase."]
     on_double_tap: Box<dyn for<'r> FnMut(&'r mut PointerEvent)>,
-    #[doc="specify the event handler for the pointer triple tap event."]
-    on_tripe_tap: Box<dyn for<'r> FnMut(&'r mut PointerEvent)>,
-    #[doc="specify the event handler for the pointer `x` times tap event."]
+    #[doc="specify the event handler for the pointer triple tap event in bubble phase."]
+    on_triple_tap: Box<dyn for<'r> FnMut(&'r mut PointerEvent)>,
+    #[doc="specify the event handler for the pointer `x` times tap event in bubble phase."]
     on_x_times_tap: (usize, Box<dyn for<'r> FnMut(&'r mut PointerEvent)>),
 
-    #[doc= "return an observable stream of the pointer tap event"]
+    #[doc= "return an observable stream of the pointer tap event in bubble phase."]
     fn tap_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
 
-    #[doc=" Return an observable stream of double tap event"]
+    #[doc=" Return an observable stream of double tap event in bubble phase."]
     fn double_tap_stream(
       &self,
     ) -> FilterMapOp<
@@ -49,7 +70,7 @@ builtin! {
       &mut PointerEvent,
     >,
 
-    #[doc="Return an observable stream of tripe tap event"]
+    #[doc="Return an observable stream of tripe tap event in bubble phase."]
     fn triple_tap_stream(
       &self,
     ) -> FilterMapOp<
@@ -57,9 +78,54 @@ builtin! {
       impl FnMut(&mut PointerEvent) -> Option<&mut PointerEvent>,
       &mut PointerEvent,
     >,
+
     #[doc=" Return an observable stream of x-tap event that user tapped 'x' \
-    times in the specify duration `dur`."]
+    times in the specify duration `dur` in bubble phase."]
     fn x_times_tap_stream(
+      &self,
+      x: usize,
+      dur: Duration,
+    ) -> FilterMapOp<
+      MutRefItemSubject<'static, PointerEvent, ()>,
+      impl FnMut(&mut PointerEvent) -> Option<&mut PointerEvent>,
+      &mut PointerEvent,
+    >,
+  }
+
+  TapCaptureListener {
+    #[doc="specify the event handler for the pointer tap event in capture phase."]
+    on_tap_capture: impl FnMut(&mut PointerEvent),
+    #[doc="specify the event handler for the pointer double tap event in capture phase."]
+    on_double_tap_capture: Box<dyn for<'r> FnMut(&'r mut PointerEvent)>,
+    #[doc="specify the event handler for the pointer triple tap event in capture phase."]
+    on_triple_tap_capture: Box<dyn for<'r> FnMut(&'r mut PointerEvent)>,
+    #[doc="specify the event handler for the pointer `x` times tap event in capture phase."]
+    on_x_times_tap_capture: (usize, Box<dyn for<'r> FnMut(&'r mut PointerEvent)>),
+    
+    #[doc= "return an observable stream of the pointer tap event in capture phase."]
+    fn tap_capture_stream(&self) -> MutRefItemSubject<'static, PointerEvent, ()>,
+
+    #[doc="return an observable stream of double tap event in capture phase."]
+    fn double_tap_capture_stream(
+      &self,
+    ) -> FilterMapOp<
+      MutRefItemSubject<'static, PointerEvent, ()>,
+      impl FnMut(&mut PointerEvent) -> Option<&mut PointerEvent>,
+      &mut PointerEvent,
+    >,
+
+    #[doc="Return an observable stream of tripe tap event in capture phase."]
+    fn triple_tap_capture_stream(
+      &self,
+    ) -> FilterMapOp<
+      MutRefItemSubject<'static, PointerEvent, ()>,
+      impl FnMut(&mut PointerEvent) -> Option<&mut PointerEvent>,
+      &mut PointerEvent,
+    >,
+
+    #[doc=" Return an observable stream of x-tap event that user tapped 'x' \
+    times in the specify duration `dur` in capture phase."]
+    fn x_times_tap_capture_stream(
       &self,
       x: usize,
       dur: Duration,
@@ -121,17 +187,31 @@ builtin! {
   }
 
   FocusInListener {
-    #[doc="specify the event handler to process focusin event."]
+    #[doc="specify the event handler to process focusin event in bubble phase."]
     on_focus_in: impl FnMut(&mut FocusEvent),
-    #[doc= "return an observable stream of the pointer focus-in event"]
+    #[doc="return an observable stream of the pointer focus-in event in bubble phase."]
     fn focus_in_stream(&self) -> MutRefItemSubject<'static, FocusEvent, ()>,
   }
 
+  FocusInCaptureListener {
+    #[doc="specify the event handler to process focusin event in capture phase."]
+    on_focus_in_capture: impl FnMut(&mut FocusEvent),
+    #[doc="return an observable stream of the pointer focus-in event in capture phase."]
+    fn focus_in_capture_stream(&self) -> MutRefItemSubject<'static, FocusEvent, ()>,
+  }
+
   FocusOutListener{
-    #[doc="specify the event handler to process focusout event."]
+    #[doc="specify the event handler to process focusout event in bubble phase."]
     on_focus_out: impl FnMut(&mut FocusEvent),
-    #[doc= "return an observable stream of the pointer focus-out event"]
+    #[doc="return an observable stream of the pointer focus-out event in bubble phase."]
     fn focus_out_stream(&self) -> MutRefItemSubject<'static, FocusEvent, ()>,
+  }
+
+  FocusOutCaptureListener {
+    #[doc="specify the event handler to process focusout event in capture phase."]
+    on_focus_out_capture: impl FnMut(&mut FocusEvent),
+    #[doc="return an observable stream of the pointer focus-out event in capture phase."]
+    fn focus_out_capture_stream(&self) -> MutRefItemSubject<'static, FocusEvent, ()>,
   }
 
   HasFocus {
@@ -140,32 +220,61 @@ builtin! {
   }
 
   KeyDownListener {
-    #[doc="specify the event handler when keyboard press down."]
+    #[doc="specify the event handler when keyboard press down in bubble phase."]
     on_key_down: impl FnMut(&mut KeyboardEvent),
-    #[doc= "return an observable stream of the key down event"]
+    #[doc="return an observable stream of the key down event in bubble phase."]
     fn key_down_stream(&self) -> MutRefItemSubject<'static, KeyboardEvent, ()>,
   }
 
+  KeyDownCaptureListener {
+    #[doc="specify the event handler when keyboard press down in capture phase."]
+    on_key_down_capture: impl FnMut(&mut KeyboardEvent),
+    #[doc="return an observable stream of the key down event in capture phase."]
+    fn key_down_capture_stream(&self) -> MutRefItemSubject<'static, KeyboardEvent, ()>,
+  }
+
   KeyUpListener {
-    #[doc="specify the event handler when a key is released."]
+    #[doc="specify the event handler when a key is released in bubble phase."]
     on_key_up: impl FnMut(&mut KeyboardEvent),
-    #[doc= "return an observable stream of the key up event"]
+    #[doc="return an observable stream of the key up event in bubble phase."]
     fn key_up_stream(&self) -> MutRefItemSubject<'static, KeyboardEvent, ()>,
   }
 
+  KeyUpCaptureListener {
+    #[doc="specify the event handler when a key is released in capture phase."]
+    on_key_up_capture: impl FnMut(&mut KeyboardEvent),
+    #[doc="return an observable stream of the key up event in capture phase."]
+    fn key_up_capture_stream(&self) -> MutRefItemSubject<'static, KeyboardEvent, ()>,
+  }
+
   CharsListener {
-    #[doc="specify the event handler when received unicode characters."]
+    #[doc="specify the event handler when received unicode characters in bubble phase."]
     on_chars: impl FnMut(&mut CharsEvent),
-    #[doc= "return an observable stream of the char event"]
+    #[doc="return an observable stream of the chars event in bubble phase."]
     fn chars_stream(&self) -> MutRefItemSubject<'static, CharsEvent, ()>,
   }
 
+  CharsCaptureListener {
+    #[doc="specify the event handler when received unicode characters in capture phase."]
+    on_chars_capture: impl FnMut(&mut CharsEvent),
+    #[doc="return an observable stream of the chars event in capture phase."]
+    fn chars_capture_stream(&self) -> MutRefItemSubject<'static, CharsEvent, ()>,
+  }
+
   WheelListener {
-    #[doc="specify the event handler when user moving a mouse wheel or similar input device."]
+    #[doc="specify the event handler when user moving a mouse wheel or similar input device in bubble phase."]
     on_wheel: impl FnMut(&mut WheelEvent),
-    #[doc= "return an observable stream of the wheel event"]
+    #[doc="return an observable stream of the wheel event in bubble phase."]
     fn key_down_stream(&self) -> MutRefItemSubject<'static, WheelEvent, ()>,
   }
+
+  WheelCaptureListener {
+    #[doc="specify the event handler when user moving a mouse wheel or similar input device in capture phase."]
+    on_wheel_capture: impl FnMut(&mut WheelEvent),
+    #[doc="return an observable stream of the wheel event in capture phase."]
+    fn wheel_capture_stream(&self) -> MutRefItemSubject<'static, WheelEvent, ()>,
+  }
+
   MouseHover {
     #[doc="return if the pointer is hover on the widget"]
     fn mouse_hover(&self) -> bool,


### PR DESCRIPTION
## Background

Ribir Framework only support bubble event now, some scenarios require event capture mechanisms, so support is needed.

## Current Status

Ribir Framework support events:

| Event Name     | Bubble | Capture |
| -------------- | ------ | ------- |
| chars          | true   | no yet  |
| focus          | false  | false   |
| blur           | false  | false   |
| focus in       | true   | no yet  |
| focus out      | true   | no yet  |
| key down       | true   | no yet  |
| key up         | true   | no yet  |
| pointer down   | true   | no yet  |
| pointer up     | true   | no yet  |
| pointer move   | true   | no yet  |
| tap            | true   | no yet  |
| pointer cancel | false  | false   |
| pointer enter  | false  | false   |
| pointer leave  | false  | false   |
| wheel          | true   | false   |

So we need to support the above capture events that are not yet implemented.