### PR TITLE
Refactor/shared app

### DIFF
--- a/core/src/animation/animate.rs
+++ b/core/src/animation/animate.rs
@@ -182,7 +182,7 @@ mod tests {
     let mut themes = vec![];
     let pool = FuturesLocalSchedulerPool::default();
     let scheduler = pool.spawner();
-    let mut wnd_ctx = WindowCtx::new(<_>::default(), scheduler);
+    let mut wnd_ctx = WindowCtx::new(scheduler);
     let ctx = BuildCtx::new(&mut themes, &mut wnd_ctx);
     let animate = Animate::declare_builder()
       .transition(

--- a/core/src/builtin_widgets/cursor.rs
+++ b/core/src/builtin_widgets/cursor.rs
@@ -95,6 +95,8 @@ mod tests {
 
   #[test]
   fn tree_down_up() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let row_tree = widget! {
       MockBox {
         size: Size::new(f32::INFINITY, f32::INFINITY),

--- a/core/src/builtin_widgets/fitted_box.rs
+++ b/core/src/builtin_widgets/fitted_box.rs
@@ -119,6 +119,8 @@ mod tests {
 
   #[test]
   fn fit_test() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let small_size: Size = Size::new(100., 150.);
 
     FitTestCase {

--- a/core/src/builtin_widgets/focus_scope.rs
+++ b/core/src/builtin_widgets/focus_scope.rs
@@ -47,6 +47,8 @@ mod tests {
 
   #[test]
   fn tab_scope() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Size::zero();
     let widget = widget! {
       MockMulti {
@@ -103,6 +105,8 @@ mod tests {
 
   #[test]
   fn tab_scope_self_only() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Size::zero();
     let widget = widget! {
       MockMulti {
@@ -149,6 +153,8 @@ mod tests {
 
   #[test]
   fn focus_scope() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Size::new(50., 50.);
     let tap_cnt = Rc::new(RefCell::new(0));
     let result = tap_cnt.clone();

--- a/core/src/builtin_widgets/lifecycle.rs
+++ b/core/src/builtin_widgets/lifecycle.rs
@@ -208,7 +208,7 @@ mod tests {
     };
 
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     assert_eq!(&**lifecycle.state_ref(), ["static mounted"]);
     tree.layout(Size::new(100., 100.));
     assert_eq!(
@@ -266,7 +266,7 @@ mod tests {
     };
 
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::new(100., 100.));
     let mounted_ids = (*mounted.state_ref()).clone();
 

--- a/core/src/builtin_widgets/scrollable.rs
+++ b/core/src/builtin_widgets/scrollable.rs
@@ -149,6 +149,8 @@ mod tests {
 
   #[test]
   fn x_scroll() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     test_assert(Scrollable::X, -10., -10., -10., 0.);
     test_assert(Scrollable::X, -10000., -10., -900., 0.);
     test_assert(Scrollable::X, 100., -10., 0., 0.);
@@ -156,6 +158,8 @@ mod tests {
 
   #[test]
   fn y_scroll() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     test_assert(Scrollable::Y, -10., -10., 0., -10.);
     test_assert(Scrollable::Y, -10., -10000., 0., -900.);
     test_assert(Scrollable::Y, 10., 100., 0., 0.);
@@ -163,6 +167,8 @@ mod tests {
 
   #[test]
   fn both_scroll() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     test_assert(Scrollable::Both, -10., -10., -10., -10.);
     test_assert(Scrollable::Both, -10000., -10000., -900., -900.);
     test_assert(Scrollable::Both, 100., 100., 0., 0.);
@@ -189,6 +195,8 @@ mod tests {
 
   #[test]
   fn scroll_content_expand() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       FixedBox {
         size: Size::new(200., 200.),

--- a/core/src/builtin_widgets/theme.rs
+++ b/core/src/builtin_widgets/theme.rs
@@ -83,7 +83,7 @@ impl ComposeChild for ThemeWidget {
   fn compose_child(this: State<Self>, child: Self::Child) -> Widget {
     use crate::prelude::*;
     widget! {
-      init ctx => { ctx.app_ctx().load_font_from_theme(&this.theme); }
+      init ctx => {  AppCtx::load_font_from_theme(&this.theme); }
       states { this: this.into_readonly() }
       DynWidget {
         dyns: move |ctx: &BuildCtx| {

--- a/core/src/builtin_widgets/theme/compose_decorators.rs
+++ b/core/src/builtin_widgets/theme/compose_decorators.rs
@@ -102,7 +102,7 @@ mod tests {
       }}
     };
 
-    let ctx = AppContext::new(theme);
+    let ctx = AppContext::new(theme, Box::new(MockWaker));
     let mut wnd = TestWindow::new_with_ctx(w, Size::new(500., 500.), ctx);
     wnd.draw_frame();
     assert_layout_result_by_path!(

--- a/core/src/builtin_widgets/theme/compose_decorators.rs
+++ b/core/src/builtin_widgets/theme/compose_decorators.rs
@@ -76,6 +76,8 @@ mod tests {
 
   #[test]
   fn compose_decorator_smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let mut theme = FullTheme::default();
 
     #[derive(Declare)]
@@ -102,8 +104,9 @@ mod tests {
       }}
     };
 
-    let ctx = AppContext::new(theme, Box::new(MockWaker));
-    let mut wnd = TestWindow::new_with_ctx(w, Size::new(500., 500.), ctx);
+    unsafe { AppCtx::set_app_theme(theme) };
+
+    let mut wnd = TestWindow::new_with_size(w, Size::new(500., 500.));
     wnd.draw_frame();
     assert_layout_result_by_path!(
       wnd,

--- a/core/src/context/app_context.rs
+++ b/core/src/context/app_context.rs
@@ -5,9 +5,10 @@ use crate::{
 use pin_project_lite::pin_project;
 use std::{
   cell::RefCell,
-  ptr::NonNull,
   rc::Rc,
+  sync::{Mutex, MutexGuard, Once},
   task::{Context, RawWaker, RawWakerVTable, Waker},
+  thread::ThreadId,
 };
 
 use crate::prelude::FuturesLocalScheduler;
@@ -25,125 +26,196 @@ pub trait RuntimeWaker {
   fn wake(&self);
 }
 
-#[derive(Clone)]
-pub struct AppContext {
-  // todo: tmp code, We'll share AppContext by reference.
-  app_theme: NonNull<Theme>,
-  pub font_db: Rc<RefCell<FontDB>>,
-  pub shaper: TextShaper,
-  pub reorder: TextReorder,
-  pub typography_store: TypographyStore,
-  pub clipboard: Rc<RefCell<dyn Clipboard>>,
-  pub runtime_waker: Box<dyn RuntimeWaker + Send>,
-  executor: Executor,
+/// The context is shared throughout the application, "AppCtx" is not
+/// thread-safe, and only allowed to be used in the first thread that uses
+/// "AppCtx".
+///
+/// All mutable methods of "AppCtx" are unsafe, and should call the mutable
+/// methods before application startup, all the mutable calls during the
+/// application running is dangerous. Because the reference of "AppCtx" maybe
+/// already hold by others.
+pub struct AppCtx {
+  app_theme: Theme,
+  font_db: Rc<RefCell<FontDB>>,
+  shaper: TextShaper,
+  reorder: TextReorder,
+  typography_store: TypographyStore,
+  clipboard: RefCell<Box<dyn Clipboard>>,
+  runtime_waker: Box<dyn RuntimeWaker + Send>,
+  executor: RefCell<LocalPool>,
 }
 
-#[derive(Clone)]
-pub struct Executor {
-  local: Rc<RefCell<LocalPool>>,
-}
+static mut INIT_THREAD_ID: Option<ThreadId> = None;
+static mut APP_CTX_INIT: Once = Once::new();
+static mut APP_CTX: Option<AppCtx> = None;
 
-impl Default for Executor {
-  fn default() -> Self {
-    Self {
-      local: Rc::new(RefCell::new(LocalPool::default())),
-    }
-  }
-}
+impl AppCtx {
+  /// Get the global application context, it's not thread safe, you can only use
+  /// it in the first thread that uses it.
+  #[track_caller]
+  pub fn shared() -> &'static Self { unsafe { Self::shared_mut() } }
 
-impl AppContext {
-  pub fn new(theme: FullTheme, runtime_waker: Box<dyn RuntimeWaker + Send>) -> Self {
-    // temp leak
-    let theme = Box::new(Theme::Full(theme));
-    let app_theme = Box::leak(theme).into();
+  /// Get the theme of the application.
+  #[track_caller]
+  pub fn app_theme() -> &'static Theme { &Self::shared().app_theme }
 
-    let mut font_db = FontDB::default();
-    font_db.load_system_fonts();
-    let font_db = Rc::new(RefCell::new(font_db));
-    let shaper = TextShaper::new(font_db.clone());
-    let reorder = TextReorder::default();
-    let typography_store = TypographyStore::new(reorder.clone(), font_db.clone(), shaper.clone());
+  /// Get the scheduler of the application.
+  #[track_caller]
+  pub fn scheduler() -> FuturesLocalScheduler { Self::shared().executor.borrow_mut().spawner() }
 
-    let ctx = AppContext {
-      font_db,
-      app_theme,
-      shaper,
-      reorder,
-      typography_store,
-      clipboard: Rc::new(RefCell::new(MockClipboard {})),
-      executor: <_>::default(),
-      runtime_waker,
-    };
-    ctx.load_font_from_theme(ctx.app_theme());
-    ctx
-  }
+  /// Get the clipboard of the application.
+  #[track_caller]
+  pub fn clipboard() -> &'static RefCell<Box<dyn Clipboard>> { &Self::shared().clipboard }
 
-  pub fn app_theme(&self) -> &Theme { unsafe { self.app_theme.as_ref() } }
+  /// Get the typography store of the application.
+  #[track_caller]
+  pub fn typography_store() -> &'static TypographyStore { &Self::shared().typography_store }
 
-  // todo: should &mut self here, but we need to remove `init ctx =>` first
-  #[allow(clippy::mut_from_ref)]
-  pub fn app_theme_mut(&self) -> &mut Theme {
-    let mut ptr = self.app_theme;
-    // tmp code
-    unsafe { &mut *ptr.as_mut() }
+  /// Get the font database of the application.
+  #[track_caller]
+  pub fn font_db() -> &'static Rc<RefCell<FontDB>> { &Self::shared().font_db }
+
+  /// Runs all tasks in the local(usually means on the main thread) pool and
+  /// returns if no more progress can be made on any task.
+  #[track_caller]
+  pub fn run_until_stalled() { Self::shared().executor.borrow_mut().run_until_stalled() }
+
+  /// Loads the font from the theme config and import it into the font database.
+  #[track_caller]
+  pub fn load_font_from_theme(theme: &Theme) {
+    let mut font_db = Self::shared().font_db.borrow_mut();
+    load_font_from_theme(theme, &mut font_db);
   }
 
-  pub fn scheduler(&self) -> FuturesLocalScheduler { self.executor.local.borrow().spawner() }
-
-  pub(crate) fn end_frame(&mut self) {
-    // todo: frame cache is not a good choice? because not every text will relayout
-    // in every frame.
-    self.shaper.end_frame();
-    self.reorder.end_frame();
-    self.typography_store.end_frame();
-  }
-
-  pub fn load_font_from_theme(&self, theme: &Theme) {
-    let mut font_db = self.font_db.borrow_mut();
-    match theme {
-      Theme::Full(FullTheme { font_bytes, font_files, .. })
-      | Theme::Inherit(InheritTheme { font_bytes, font_files, .. }) => {
-        if let Some(font_bytes) = font_bytes {
-          font_bytes
-            .iter()
-            .for_each(|data| font_db.load_from_bytes(data.clone()));
-        }
-        if let Some(font_files) = font_files {
-          font_files.iter().for_each(|path| {
-            let _ = font_db.load_font_file(path);
-          });
-        }
+  /// Check if the calling thread is the thread that initializes the `AppCtx`,
+  /// you needn't use this method manually, it's called automatically when you
+  /// use the methods of `AppCtx`. But it's useful when you want your code to
+  /// keep same behavior like `AppCtx`.
+  pub fn thread_check() {
+    let current_thread = std::thread::current().id();
+    unsafe {
+      if Some(current_thread) != INIT_THREAD_ID {
+        panic!(
+          "AppCtx::shared() should be called only in one thread {:?} != {:?}.",
+          Some(current_thread),
+          INIT_THREAD_ID
+        );
       }
     }
   }
 
-  /// Runs all tasks in the local(usually means on the main thread) pool and
-  /// returns if no more progress can be made on any task.
-  pub fn run_until_stalled(&self) { self.executor.local.borrow_mut().run_until_stalled() }
+  /// Set the theme of the application
+  ///
+  /// # Safety
+  /// This should be only called before application startup. The behavior is
+  /// undefined if you call it in a running application.
+  #[track_caller]
+  pub unsafe fn set_app_theme(theme: FullTheme) {
+    Self::shared_mut().app_theme = Theme::Full(theme);
+    load_font_from_theme(Self::app_theme(), &mut Self::font_db().borrow_mut());
+  }
+
+  /// Set the shared clipboard of the application, this should be called before
+  /// application startup.
+  ///
+  /// # Safety
+  /// This should be only called before application startup. The behavior is
+  /// undefined if you call it in a running application.
+  #[track_caller]
+  pub unsafe fn set_clipboard(clipboard: Box<dyn Clipboard>) {
+    Self::shared_mut().clipboard = RefCell::new(clipboard);
+  }
+
+  /// Set the runtime waker of the application, this should be called before
+  /// application startup.
+  /// # Safety
+  /// This should be only called before application startup. The behavior is
+  /// undefined if you call it in a running application.
+  #[track_caller]
+  pub unsafe fn set_runtime_waker(waker: Box<dyn RuntimeWaker + Send>) {
+    Self::shared_mut().runtime_waker = waker;
+  }
+
+  /// Start a new scope to mock a new application startup for `AppCtx`, this
+  /// will force reset the application context and return a lock guard. The
+  /// lock guard prevents two scope have intersecting lifetime.
+  ///
+  /// In normal case, you should not directly call this method in your
+  /// production code, use only if you have same requirement and know how
+  /// `new_lock_scope` works.
+  ///
+  /// It's useful for unit test and server side rendering. Because many tests
+  /// are runnings parallels in one process, we call this method before each
+  /// test that uses `AppCtx` to ensure every test has a clean `AppCtx`. For
+  /// server-side it's can help to reuse the process resource.
+  ///
+  /// # Safety
+  /// If your application want create multi `AppCtx` instances, hold a scope for
+  /// every instance. Otherwise, the behavior is undefined.
+  #[track_caller]
+  pub unsafe fn new_lock_scope() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    let locker = LOCK.lock().unwrap();
+    APP_CTX_INIT = Once::new();
+    locker
+  }
+
+  #[track_caller]
+  pub(crate) fn end_frame() {
+    // todo: frame cache is not a good choice? because not every text will relayout
+    // in every frame.
+    let ctx = unsafe { Self::shared_mut() };
+    ctx.shaper.end_frame();
+    ctx.reorder.end_frame();
+    ctx.typography_store.end_frame();
+  }
+
+  #[track_caller]
+  unsafe fn shared_mut() -> &'static mut Self {
+    APP_CTX_INIT.call_once(|| {
+      let app_theme = Theme::Full(<_>::default());
+      let mut font_db = FontDB::default();
+      font_db.load_system_fonts();
+      load_font_from_theme(&app_theme, &mut font_db);
+      let font_db = Rc::new(RefCell::new(font_db));
+      let shaper = TextShaper::new(font_db.clone());
+      let reorder = TextReorder::default();
+      let typography_store = TypographyStore::new(reorder.clone(), font_db.clone(), shaper.clone());
+
+      let ctx = AppCtx {
+        font_db,
+        app_theme,
+        shaper,
+        reorder,
+        typography_store,
+        clipboard: RefCell::new(Box::new(MockClipboard {})),
+        executor: <_>::default(),
+        runtime_waker: Box::new(MockWaker),
+      };
+
+      INIT_THREAD_ID = Some(std::thread::current().id());
+      APP_CTX = Some(ctx);
+    });
+
+    Self::thread_check();
+    APP_CTX.as_mut().unwrap_unchecked()
+  }
 }
 
-impl Default for AppContext {
-  fn default() -> Self { AppContext::new(<_>::default(), Box::new(MockWaker)) }
-}
-
-impl AppContext {
+impl AppCtx {
   pub fn wait_future<F: Future>(f: F) -> F::Output { block_on(f) }
 
   #[inline]
-  pub fn spawn_local<Fut>(&self, future: Fut) -> Result<(), SpawnError>
+  pub fn spawn_local<Fut>(future: Fut) -> Result<(), SpawnError>
   where
     Fut: Future<Output = ()> + 'static,
   {
-    self.runtime_waker.wake();
-    self
-      .executor
-      .local
-      .borrow()
-      .spawner()
-      .spawn_local(LocalFuture {
-        fut: future,
-        waker: self.runtime_waker.clone(),
-      })
+    let ctx = AppCtx::shared();
+    ctx.runtime_waker.wake();
+    ctx.executor.borrow().spawner().spawn_local(LocalFuture {
+      fut: future,
+      waker: ctx.runtime_waker.clone(),
+    })
   }
 }
 
@@ -227,6 +299,24 @@ impl RuntimeWaker for MockWaker {
   fn clone_box(&self) -> Box<dyn RuntimeWaker + Send> { Box::new(MockWaker) }
 }
 
+pub fn load_font_from_theme(theme: &Theme, font_db: &mut FontDB) {
+  match theme {
+    Theme::Full(FullTheme { font_bytes, font_files, .. })
+    | Theme::Inherit(InheritTheme { font_bytes, font_files, .. }) => {
+      if let Some(font_bytes) = font_bytes {
+        font_bytes
+          .iter()
+          .for_each(|data| font_db.load_from_bytes(data.clone()));
+      }
+      if let Some(font_files) = font_files {
+        font_files.iter().for_each(|path| {
+          let _ = font_db.load_font_file(path);
+        });
+      }
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -278,6 +368,8 @@ mod tests {
 
   #[test]
   fn local_future_smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     struct WakerCnt(Arc<Mutex<usize>>);
     impl RuntimeWaker for WakerCnt {
       fn wake(&self) { *self.0.lock().unwrap() += 1; }
@@ -286,7 +378,7 @@ mod tests {
 
     let ctx_wake_cnt = Arc::new(Mutex::new(0));
     let wake_cnt = ctx_wake_cnt.clone();
-    let ctx = AppContext::new(<_>::default(), Box::new(WakerCnt(wake_cnt)));
+    unsafe { AppCtx::set_runtime_waker(Box::new(WakerCnt(wake_cnt))) }
 
     let triggers = (0..3)
       .map(|_| Rc::new(RefCell::new(Trigger::default())))
@@ -298,17 +390,17 @@ mod tests {
 
     let acc = Rc::new(RefCell::new(0));
     let sum = acc.clone();
-    let _ = ctx.spawn_local(async move {
+    let _ = AppCtx::spawn_local(async move {
       for fut in futs {
         let v = fut.await;
         *acc.borrow_mut() += v;
       }
     });
-    ctx.run_until_stalled();
+    AppCtx::run_until_stalled();
     let mut waker_cnt = *ctx_wake_cnt.lock().unwrap();
 
     // when no trigger, nothing will change
-    ctx.run_until_stalled();
+    AppCtx::run_until_stalled();
     assert_eq!(*sum.borrow(), 0);
     assert_eq!(*ctx_wake_cnt.lock().unwrap(), waker_cnt);
 
@@ -317,7 +409,7 @@ mod tests {
       trigger.borrow_mut().trigger();
       waker_cnt += 1;
       assert_eq!(*ctx_wake_cnt.lock().unwrap(), waker_cnt);
-      ctx.run_until_stalled();
+      AppCtx::run_until_stalled();
       assert_eq!(*sum.borrow(), idx + 1);
     }
   }

--- a/core/src/context/build_context.rs
+++ b/core/src/context/build_context.rs
@@ -24,11 +24,8 @@ impl<'a> BuildCtx<'a> {
         return None;
       }
     }
-    f(self.app_theme())
+    f(AppCtx::app_theme())
   }
-
-  #[inline]
-  pub fn app_ctx(&self) -> &AppContext { &self.wnd_ctx.app_ctx }
 
   #[inline]
   // todo: should &mut self here, but we need to remove `init ctx =>` first
@@ -37,12 +34,6 @@ impl<'a> BuildCtx<'a> {
     let this = unsafe { &mut *(self as *const Self as *mut Self) };
     this.themes.push(theme);
   }
-
-  #[inline]
-  pub(crate) fn app_theme(&self) -> &Theme { self.app_ctx().app_theme() }
-
-  #[inline]
-  pub(crate) fn app_theme_mut(&self) -> &mut Theme { self.wnd_ctx.app_ctx.app_theme_mut() }
 }
 
 #[cfg(test)]
@@ -53,6 +44,8 @@ mod tests {
 
   #[test]
   fn themes() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Default, Clone)]
     struct LightDarkThemes(Rc<RefCell<Vec<Theme>>>);
 

--- a/core/src/context/event_context.rs
+++ b/core/src/context/event_context.rs
@@ -1,8 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
-use super::{define_widget_context, AppContext, WidgetCtxImpl, WindowCtx};
-use crate::clipboard::Clipboard;
+use super::{define_widget_context, WidgetCtxImpl, WindowCtx};
 use crate::context::widget_context::WidgetContext;
 use crate::{
   events::dispatcher::DispatchInfo,
@@ -30,8 +26,4 @@ impl<'a> EventCtx<'a> {
     let pos = self.map_to_global(pos);
     wnd_ctx.set_ime_pos(pos);
   }
-
-  pub fn clipboard(&self) -> Rc<RefCell<dyn Clipboard>> { self.wnd_ctx.app_ctx.clipboard.clone() }
-
-  pub fn app_ctx(&self) -> &AppContext { self.wnd_ctx.app_ctx() }
 }

--- a/core/src/context/painting_context.rs
+++ b/core/src/context/painting_context.rs
@@ -1,5 +1,3 @@
-use ribir_text::TypographyStore;
-
 use crate::{
   prelude::{Painter, WidgetId},
   widget::{LayoutStore, TreeArena},
@@ -13,7 +11,4 @@ impl<'a> PaintingCtx<'a> {
   /// Return the 2d painter to draw 2d things.
   #[inline]
   pub fn painter(&mut self) -> &mut Painter { self.painter }
-
-  #[inline]
-  pub fn typography_store(&self) -> &TypographyStore { self.wnd_ctx.typography_store() }
 }

--- a/core/src/context/widget_context.rs
+++ b/core/src/context/widget_context.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use ribir_geom::{Point, Rect, Size};
 
-use super::{AppContext, WindowCtx};
+use super::WindowCtx;
 
 /// common action for all context of widget.
 pub trait WidgetContext {
@@ -55,8 +55,6 @@ pub trait WidgetContext {
   fn query_widget_type<T: 'static>(&self, id: WidgetId, callback: impl FnOnce(&T));
 
   fn wnd_ctx(&self) -> &WindowCtx;
-
-  fn app_ctx(&self) -> &AppContext { &self.wnd_ctx().app_ctx }
 }
 
 pub(crate) trait WidgetCtxImpl {
@@ -216,6 +214,8 @@ mod tests {
 
   #[test]
   fn map_self_eq_self() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       MockBox {
         size: Size::zero(),
@@ -237,6 +237,8 @@ mod tests {
 
   #[test]
   fn map_transform_test() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       MockBox {
         size: Size::new(100., 100.),

--- a/core/src/dynamic_widget.rs
+++ b/core/src/dynamic_widget.rs
@@ -496,6 +496,8 @@ mod tests {
 
   #[test]
   fn expr_widget_as_root() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Stateful::new(Size::zero());
     let w = widget! {
       states { size: size.clone() }
@@ -505,7 +507,7 @@ mod tests {
       }
     };
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::zero());
     let ids = tree.root().descendants(&tree.arena).collect::<Vec<_>>();
     assert_eq!(ids.len(), 2);
@@ -521,6 +523,8 @@ mod tests {
 
   #[test]
   fn expr_widget_with_declare_child() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Stateful::new(Size::zero());
     let w = widget! {
       states { size: size.clone() }
@@ -532,9 +536,8 @@ mod tests {
         }
       }
     };
-    let app_ctx = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(app_ctx, scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::zero());
     let ids = tree.root().descendants(&tree.arena).collect::<Vec<_>>();
     assert_eq!(ids.len(), 3);
@@ -551,6 +554,8 @@ mod tests {
 
   #[test]
   fn expr_widget_mounted_new() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let v = Stateful::new(vec![1, 2, 3]);
 
     let new_cnt = Stateful::new(0);
@@ -577,7 +582,7 @@ mod tests {
       }}
     };
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::zero());
     assert_eq!(*new_cnt.state_ref(), 3);
     assert_eq!(*drop_cnt.state_ref(), 0);
@@ -595,6 +600,8 @@ mod tests {
 
   #[test]
   fn dyn_widgets_with_key() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let v = Stateful::new(vec![(1, '1'), (2, '2'), (3, '3')]);
     let enter_list: Stateful<Vec<char>> = Stateful::new(vec![]);
     let update_list: Stateful<Vec<char>> = Stateful::new(vec![]);
@@ -646,9 +653,8 @@ mod tests {
     };
 
     // 1. 3 item enter
-    let app_ctx = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(app_ctx, scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::zero());
     let expect_vec = vec!['1', '2', '3'];
     assert_eq!((*enter_list.state_ref()).len(), 3);
@@ -727,6 +733,8 @@ mod tests {
 
   #[test]
   fn delay_drop_widgets() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Default, Clone)]
     struct Task {
       mounted: u32,
@@ -878,6 +886,8 @@ mod tests {
 
   #[test]
   fn remove_delay_drop_widgets() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let child = Stateful::new(Some(()));
     let child_destroy_until = Stateful::new(false);
     let grandson = Stateful::new(Some(()));

--- a/core/src/events/character.rs
+++ b/core/src/events/character.rs
@@ -73,6 +73,7 @@ mod tests {
 
   #[test]
   fn smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     let receive = Rc::new(RefCell::new("".to_string()));
     let c_receive = receive.clone();
 
@@ -97,6 +98,7 @@ mod tests {
 
   #[test]
   fn chars_capture() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     let receive = Rc::new(RefCell::new("".to_string()));
     let chars_receive = receive.clone();
     let capture_receive = receive.clone();

--- a/core/src/events/dispatcher.rs
+++ b/core/src/events/dispatcher.rs
@@ -495,6 +495,8 @@ mod tests {
 
   #[test]
   fn mouse_pointer_bubble() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let event_record = Rc::new(RefCell::new(vec![]));
     let record = record_pointer(
       event_record.clone(),
@@ -538,6 +540,8 @@ mod tests {
 
   #[test]
   fn mouse_buttons() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let event_record = Rc::new(RefCell::new(vec![]));
     let root = record_pointer(
       event_record.clone(),
@@ -601,6 +605,8 @@ mod tests {
   #[cfg(not(target_os = "macos"))]
   #[test]
   fn different_device_mouse() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let event_record = Rc::new(RefCell::new(vec![]));
     let root = record_pointer(
       event_record.clone(),
@@ -668,6 +674,7 @@ mod tests {
 
   #[test]
   fn cancel_bubble() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     #[derive(Default)]
     struct EventRecord(Rc<RefCell<Vec<PointerEvent>>>);
     impl Compose for EventRecord {
@@ -709,6 +716,8 @@ mod tests {
 
   #[test]
   fn enter_leave() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Default)]
     struct EnterLeave {
       enter: Rc<RefCell<Vec<i32>>>,
@@ -796,6 +805,8 @@ mod tests {
 
   #[test]
   fn capture_click() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let click_path = Stateful::new(vec![]) as Stateful<Vec<usize>>;
     let w = widget! {
       states { click_path: click_path.clone() }
@@ -847,6 +858,8 @@ mod tests {
 
   #[test]
   fn click() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let click_path = Stateful::new(0);
     let w = widget! {
       states { click_path: click_path.clone() }
@@ -929,6 +942,8 @@ mod tests {
 
   #[test]
   fn focus_change_by_event() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       MockMulti {
         MockBox {
@@ -988,6 +1003,8 @@ mod tests {
 
   #[test]
   fn fix_hit_out_window() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = MockBox { size: INFINITY_SIZE };
     let mut wnd = TestWindow::new(w);
     wnd.draw_frame();
@@ -999,6 +1016,8 @@ mod tests {
 
   #[test]
   fn hit_test_case() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     fn normal_mode_search() {
       struct T {
         pub wid1: Option<WidgetId>,

--- a/core/src/events/focus_mgr.rs
+++ b/core/src/events/focus_mgr.rs
@@ -619,6 +619,8 @@ mod tests {
 
   #[test]
   fn two_auto_focus() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     // two auto focus widget
     let size = Size::zero();
     let widget = widget! {
@@ -639,6 +641,7 @@ mod tests {
 
   #[test]
   fn on_auto_focus() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     // one auto focus widget
     let size = Size::zero();
     let widget = widget! {
@@ -662,6 +665,8 @@ mod tests {
 
   #[test]
   fn tab_index() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let size = Size::zero();
     let widget = widget! {
       MockMulti {
@@ -721,6 +726,8 @@ mod tests {
 
   #[test]
   fn focus_event() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Debug, Default)]
     struct EmbedFocus {
       log: Rc<RefCell<Vec<&'static str>>>,
@@ -778,6 +785,8 @@ mod tests {
 
   #[test]
   fn dynamic_focus() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let visible = Stateful::new(Some(()));
     let w = widget! {
       states { visible: visible.clone_stateful() }
@@ -807,6 +816,8 @@ mod tests {
 
   #[test]
   fn scope_node_request_focus() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       MockMulti{
         MockBox{

--- a/core/src/events/keyboard.rs
+++ b/core/src/events/keyboard.rs
@@ -116,6 +116,8 @@ mod tests {
 
   #[test]
   fn smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Default)]
     struct Keys(Rc<RefCell<Vec<String>>>);
 

--- a/core/src/events/pointers.rs
+++ b/core/src/events/pointers.rs
@@ -460,6 +460,8 @@ mod tests {
 
   #[test]
   fn tap_focus() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let tap_cnt = Rc::new(RefCell::new(0));
     let is_focused = Rc::new(RefCell::new(false));
 

--- a/core/src/events/wheel.rs
+++ b/core/src/events/wheel.rs
@@ -71,6 +71,8 @@ mod tests {
 
   #[test]
   fn smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let source_receive_for_bubble = Rc::new(RefCell::new((0., 0.)));
     let bubble_receive = source_receive_for_bubble.clone();
     let source_receive_for_capture = Rc::new(RefCell::new((0., 0.)));

--- a/core/src/state/stateful.rs
+++ b/core/src/state/stateful.rs
@@ -391,6 +391,8 @@ mod tests {
 
   #[test]
   fn smoke() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     // Simulate `MockBox` widget need modify its size in event callback. Can use the
     // `cell_ref` in closure.
     let stateful = Stateful::new(MockBox { size: Size::zero() });
@@ -402,6 +404,8 @@ mod tests {
 
   #[test]
   fn state_notify_and_relayout() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     use std::{cell::RefCell, rc::Rc};
     let notified_count = Rc::new(RefCell::new(0));
     let cnc = notified_count.clone();
@@ -436,6 +440,8 @@ mod tests {
 
   #[test]
   fn fix_pin_widget_node() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let mut wnd = TestWindow::new(widget! { MockBox { size: Size::new(100., 100.) } });
     wnd.draw_frame();
     let tree = &wnd.widget_tree;
@@ -444,6 +450,8 @@ mod tests {
 
   #[test]
   fn change_notify() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let notified = Rc::new(RefCell::new(vec![]));
     let c_notified = notified.clone();
     let w = Stateful::new(MockBox { size: Size::zero() });

--- a/core/src/test_helper.rs
+++ b/core/src/test_helper.rs
@@ -22,7 +22,6 @@ impl TestWindow {
     Self(Window::new(
       root.into_widget(),
       Box::new(TestShellWindow::new(None)),
-      <_>::default(),
     ))
   }
 
@@ -32,21 +31,6 @@ impl TestWindow {
     Self(Window::new(
       root.into_widget(),
       Box::new(TestShellWindow::new(Some(size))),
-      <_>::default(),
-    ))
-  }
-
-  pub fn new_with_ctx<M: ImplMarker>(
-    root: impl IntoWidget<M>,
-    size: Size,
-    ctx: AppContext,
-  ) -> Self {
-    let _ = NEW_TIMER_FN.set(Timer::new_timer_future);
-
-    Self(Window::new(
-      root.into_widget(),
-      Box::new(TestShellWindow::new(Some(size))),
-      ctx,
     ))
   }
 
@@ -79,6 +63,7 @@ impl TestWindow {
       .take()
   }
 
+  #[track_caller]
   pub fn draw_frame(&mut self) {
     // Test window not have a eventloop, manually wake-up every frame.
     Timer::wake_timeout_futures();

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -243,7 +243,6 @@ mod tests {
   };
 
   use super::*;
-  use ribir_text::font_db::FontDB;
   use test::Bencher;
 
   #[derive(Clone, Debug)]
@@ -308,12 +307,11 @@ mod tests {
   }
 
   fn bench_recursive_inflate(width: usize, depth: usize, b: &mut Bencher) {
-    let ctx: AppContext = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
     b.iter(move || {
       let mut tree = WidgetTree::new(
         Recursive { width, depth }.into_widget(),
-        WindowCtx::new(ctx.clone(), scheduler.clone()),
+        WindowCtx::new(scheduler.clone()),
       );
       tree.layout(Size::new(512., 512.));
     });
@@ -322,9 +320,8 @@ mod tests {
   fn bench_recursive_repair(width: usize, depth: usize, b: &mut Bencher) {
     let w = Stateful::new(Recursive { width, depth });
     let trigger = w.clone();
-    let app_ctx = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w.into_widget(), WindowCtx::new(app_ctx, scheduler));
+    let mut tree = WidgetTree::new(w.into_widget(), WindowCtx::new(scheduler));
     b.iter(|| {
       {
         let _: &mut Recursive = &mut trigger.state_ref();
@@ -335,6 +332,8 @@ mod tests {
 
   #[test]
   fn fix_relayout_incorrect_clamp() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let expect_size = Size::new(20., 20.);
     let no_boundary_size = Stateful::new(INFINITY_SIZE);
     let w = widget! {
@@ -361,6 +360,8 @@ mod tests {
 
   #[test]
   fn fix_dropped_child_expr_widget() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let parent = Stateful::new(true);
     let child = Stateful::new(true);
     let w = widget! {
@@ -387,6 +388,8 @@ mod tests {
 
   #[test]
   fn fix_child_expr_widget_same_root_as_parent() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let trigger = Stateful::new(true);
     let w = widget! {
       states { trigger: trigger.clone() }
@@ -412,12 +415,11 @@ mod tests {
   }
   #[test]
   fn drop_info_clear() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let post = Embed { width: 5, depth: 3 };
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(
-      post.into_widget(),
-      WindowCtx::new(AppContext::default(), scheduler),
-    );
+    let mut tree = WidgetTree::new(post.into_widget(), WindowCtx::new(scheduler));
     tree.layout(Size::new(512., 512.));
     assert_eq!(tree.count(), 16);
 
@@ -433,38 +435,46 @@ mod tests {
 
   #[bench]
   fn inflate_5_x_1000(b: &mut Bencher) {
-    let ctx: AppContext = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     b.iter(move || {
       let post = Embed { width: 5, depth: 1000 };
-      WidgetTree::new(
-        post.into_widget(),
-        WindowCtx::new(ctx.clone(), scheduler.clone()),
-      );
+      WidgetTree::new(post.into_widget(), WindowCtx::new(scheduler.clone()));
     });
   }
 
   #[bench]
-  fn inflate_50_pow_2(b: &mut Bencher) { bench_recursive_inflate(50, 2, b); }
+  fn inflate_50_pow_2(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_inflate(50, 2, b);
+  }
 
   #[bench]
-  fn inflate_100_pow_2(b: &mut Bencher) { bench_recursive_inflate(100, 2, b); }
+  fn inflate_100_pow_2(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_inflate(100, 2, b);
+  }
 
   #[bench]
-  fn inflate_10_pow_4(b: &mut Bencher) { bench_recursive_inflate(10, 4, b); }
+  fn inflate_10_pow_4(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_inflate(10, 4, b);
+  }
 
   #[bench]
-  fn inflate_10_pow_5(b: &mut Bencher) { bench_recursive_inflate(10, 5, b); }
+  fn inflate_10_pow_5(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_inflate(10, 5, b);
+  }
 
   #[bench]
   fn repair_5_x_1000(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     let post = Stateful::new(Embed { width: 5, depth: 1000 });
     let trigger = post.clone();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(
-      post.into_widget(),
-      WindowCtx::new(AppContext::default(), scheduler),
-    );
+    let mut tree = WidgetTree::new(post.into_widget(), WindowCtx::new(scheduler));
     b.iter(|| {
       {
         let _: &mut Embed = &mut trigger.state_ref();
@@ -474,19 +484,33 @@ mod tests {
   }
 
   #[bench]
-  fn repair_50_pow_2(b: &mut Bencher) { bench_recursive_repair(50, 2, b); }
+  fn repair_50_pow_2(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_repair(50, 2, b);
+  }
 
   #[bench]
-  fn repair_100_pow_2(b: &mut Bencher) { bench_recursive_repair(100, 2, b); }
+  fn repair_100_pow_2(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_repair(100, 2, b);
+  }
 
   #[bench]
-  fn repair_10_pow_4(b: &mut Bencher) { bench_recursive_repair(10, 4, b); }
+  fn repair_10_pow_4(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_repair(10, 4, b);
+  }
 
   #[bench]
-  fn repair_10_pow_5(b: &mut Bencher) { bench_recursive_repair(10, 5, b); }
+  fn repair_10_pow_5(b: &mut Bencher) {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+    bench_recursive_repair(10, 5, b);
+  }
 
   #[test]
   fn perf_silent_ref_should_not_dirty_expr_widget() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let trigger = Stateful::new(1);
     let widget = widget! {
       states { trigger: trigger.clone() }
@@ -502,7 +526,7 @@ mod tests {
     };
 
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(widget, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree = WidgetTree::new(widget, WindowCtx::new(scheduler));
     tree.layout(Size::new(100., 100.));
     {
       *trigger.silent_ref() = 2;
@@ -512,8 +536,7 @@ mod tests {
 
   #[test]
   fn draw_clip() {
-    let mut font_db = FontDB::default();
-    font_db.load_system_fonts();
+    let _guard = unsafe { AppCtx::new_lock_scope() };
     let win_size = Size::new(150., 50.);
     let mut painter = Painter::new(Rect::from_size(win_size));
 
@@ -527,9 +550,8 @@ mod tests {
           }})
         }
     }};
-    let app_ctx = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree1 = WidgetTree::new(w1, WindowCtx::new(app_ctx, scheduler));
+    let mut tree1 = WidgetTree::new(w1, WindowCtx::new(scheduler));
     tree1.layout(win_size);
     tree1.draw(&mut painter);
 
@@ -546,7 +568,7 @@ mod tests {
         }
     }};
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree2 = WidgetTree::new(w2, WindowCtx::new(AppContext::default(), scheduler));
+    let mut tree2 = WidgetTree::new(w2, WindowCtx::new(scheduler));
     tree2.layout(win_size);
     tree2.draw(&mut painter);
     let len_1_widget = painter.finish().len();

--- a/core/src/widget_tree/layout_info.rs
+++ b/core/src/widget_tree/layout_info.rs
@@ -451,6 +451,8 @@ mod tests {
   }
   #[test]
   fn fix_incorrect_relayout_root() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     // Can't use layout info of dirty widget to detect if the ancestors path have
     // in relayout list. Because new widget insert by `DynWidget` not have layout
     // info, but its parent have.
@@ -473,9 +475,8 @@ mod tests {
       }
     };
 
-    let app_ctx = <_>::default();
     let scheduler = FuturesLocalSchedulerPool::default().spawner();
-    let mut tree = WidgetTree::new(w, WindowCtx::new(app_ctx, scheduler));
+    let mut tree = WidgetTree::new(w, WindowCtx::new(scheduler));
     tree.layout(Size::zero());
     assert_eq!(*root_layout_cnt.state_ref(), 1);
     {
@@ -487,6 +488,8 @@ mod tests {
 
   #[test]
   fn layout_list_from_root_to_leaf() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let layout_order = Stateful::new(vec![]);
     let trigger = Stateful::new(Size::zero());
     let w = widget! {
@@ -520,6 +523,8 @@ mod tests {
 
   #[test]
   fn relayout_size() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let trigger = Stateful::new(Size::zero());
     let w = widget! {
       states {trigger: trigger.clone()}
@@ -563,6 +568,8 @@ mod tests {
 
   #[test]
   fn relayout_from_parent() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let trigger = Stateful::new(Size::zero());
     let cnt = Rc::new(RefCell::new(0));
     let cnt2 = cnt.clone();
@@ -591,6 +598,8 @@ mod tests {
 
   #[test]
   fn layout_visit_prev_position() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     #[derive(Declare)]
     struct MockWidget {
       pos: RefCell<Point>,

--- a/dev-helper/src/example_framework.rs
+++ b/dev-helper/src/example_framework.rs
@@ -41,10 +41,14 @@ macro_rules! example_framework {
     widget_image_test!($widget_fn, wnd_size = $size,);
 
     fn main() {
-      let mut app = App::new(material::purple::light());
+      unsafe {
+        AppCtx::set_app_theme(material::purple::light());
+      }
       let name = env!("CARGO_PKG_NAME");
-      app.new_window($widget_fn(), Some($size)).set_title(name);
-      app.exec()
+      App::new_window($widget_fn(), Some($size), |wnd| {
+        wnd.set_title(name);
+      });
+      App::exec();
     }
   };
 }

--- a/dev-helper/src/widget_test.rs
+++ b/dev-helper/src/widget_test.rs
@@ -229,7 +229,7 @@ macro_rules! widget_image_test {
 
       #[test]
       fn [<$widget_fn _with_material_by_wgpu>]() {
-        let ctx = AppContext::new(ribir_material::purple::light());
+        let ctx = AppContext::new(ribir_material::purple::light(), Box::new(MockWaker));
         let mut wnd = TestWindow::new_with_ctx($widget_fn(), $size, ctx);
         wnd.draw_frame();
         let Frame { commands, viewport, surface} = wnd.take_last_frame().unwrap();

--- a/dev-helper/src/widget_test.rs
+++ b/dev-helper/src/widget_test.rs
@@ -144,6 +144,8 @@ macro_rules! widget_layout_test {
     paste::paste! {
       #[test]
       fn [<$widget_fn _layout>]() {
+        let _scope = unsafe { AppCtx::new_lock_scope() };
+
         let mut wnd = TestWindow::new_with_size($widget_fn(), $size);
         wnd.draw_frame();
 
@@ -217,6 +219,7 @@ macro_rules! widget_image_test {
     paste::paste! {
       #[test]
       fn [<$widget_fn _with_default_by_wgpu>]() {
+        let _scope = unsafe { AppCtx::new_lock_scope() };
         let mut wnd = TestWindow::new_with_size($widget_fn(), $size);
         wnd.draw_frame();
         let Frame { commands, viewport, surface} = wnd.take_last_frame().unwrap();
@@ -229,8 +232,10 @@ macro_rules! widget_image_test {
 
       #[test]
       fn [<$widget_fn _with_material_by_wgpu>]() {
-        let ctx = AppContext::new(ribir_material::purple::light(), Box::new(MockWaker));
-        let mut wnd = TestWindow::new_with_ctx($widget_fn(), $size, ctx);
+        let _scope = unsafe { AppCtx::new_lock_scope() };
+        unsafe { AppCtx::set_app_theme(ribir_material::purple::light()) };
+
+        let mut wnd = TestWindow::new_with_size($widget_fn(), $size);
         wnd.draw_frame();
         let Frame { commands, viewport, surface} = wnd.take_last_frame().unwrap();
         let viewport = viewport.to_i32().cast_unit();
@@ -259,9 +264,11 @@ macro_rules! widget_bench {
     paste::paste! {
       #[bench]
       fn [<$widget_fn _widget_bench>](b: &mut Bencher) {
-        let ctx = AppContext::default();
+        let _scope = unsafe { AppCtx::new_lock_scope() };
+        // init app context before benchmark
+        let _ = AppCtx::shared();
         b.iter(move || {
-          let mut wnd = TestWindow::new_with_ctx($widget_fn(), $size, ctx.clone());
+          let mut wnd = TestWindow::new_with_size($widget_fn(), $size);
           wnd.draw_frame();
         });
       }

--- a/ribir/src/backends/wgpu_backend.rs
+++ b/ribir/src/backends/wgpu_backend.rs
@@ -1,5 +1,5 @@
 use ribir_core::prelude::{
-  AntiAliasing, AppContext, Color, DeviceRect, DeviceSize, PaintCommand, PainterBackend,
+  AntiAliasing, AppCtx, Color, DeviceRect, DeviceSize, PaintCommand, PainterBackend,
 };
 use ribir_gpu::WgpuTexture;
 
@@ -15,7 +15,7 @@ impl WinitBackend for WgpuBackend {
   fn new(window: &winit::window::Window) -> WgpuBackend {
     let instance = wgpu::Instance::new(<_>::default());
     let surface = unsafe { instance.create_surface(window).unwrap() };
-    let wgpu = AppContext::wait_future(ribir_gpu::WgpuImpl::new(instance, Some(&surface)));
+    let wgpu = AppCtx::wait_future(ribir_gpu::WgpuImpl::new(instance, Some(&surface)));
     let size = window.inner_size();
     surface.configure(
       wgpu.device(),

--- a/ribir/tests/timer_test.rs
+++ b/ribir/tests/timer_test.rs
@@ -17,9 +17,9 @@ mod test_single_thread {
         id: c,
         size: Size::new(20., 20.)
       }
-      finally ctx => {
+      finally {
         observable::of(Size::new(10., 10.))
-          .delay(Duration::from_millis(10), ctx.wnd_ctx().scheduler())
+          .delay(Duration::from_millis(10), AppCtx::scheduler())
           .subscribe(move |v| c.size = v);
       }
     };
@@ -30,7 +30,7 @@ mod test_single_thread {
     assert_layout_result_by_path!(wnd, {path = [0], width == 20., height == 20.,});
 
     // keep same
-    wnd.wnd_ctx().app_ctx().run_until_stalled();
+    AppCtx::run_until_stalled();
     wnd.draw_frame();
     assert_layout_result_by_path!(wnd, {path = [0], width == 20., height == 20.,});
 
@@ -38,7 +38,7 @@ mod test_single_thread {
 
     // trigger timeout
     super::Timer::wake_timeout_futures();
-    wnd.wnd_ctx().app_ctx().run_until_stalled();
+    AppCtx::run_until_stalled();
     wnd.draw_frame();
     assert_layout_result_by_path!(wnd, {path = [0], width == 10., height == 10.,});
   }

--- a/tests/animations_syntax_test.rs
+++ b/tests/animations_syntax_test.rs
@@ -19,6 +19,8 @@ fn wheel_widget(w: Widget) -> TestWindow {
 
 #[test]
 fn listener_trigger_have_handler() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let handler_call_times = Rc::new(Cell::new(0));
   let h1 = handler_call_times.clone();
   let animate_state = Stateful::new(false);
@@ -56,6 +58,8 @@ fn listener_trigger_have_handler() {
 
 #[test]
 fn listener_trigger() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let animate_state = Stateful::new(false);
 
   let w = widget! {

--- a/tests/code_gen_test.rs
+++ b/tests/code_gen_test.rs
@@ -5,6 +5,8 @@ use winit::event::{DeviceId, ElementState, MouseButton, WindowEvent};
 
 #[test]
 fn declare_smoke() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let _ = widget! {
     SizedBox {
       size: Size::new(500.,500.),
@@ -15,6 +17,8 @@ fn declare_smoke() {
 
 #[test]
 fn simple_ref_bind_work() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let size = Size::new(100., 100.);
   let w = widget! {
     Flex {
@@ -36,8 +40,10 @@ fn simple_ref_bind_work() {
   wnd.layout();
   assert_layout_result_by_path!(wnd, { path = [0], size == flex_size * 2., });
 }
+
 #[test]
 fn event_attr_sugar_work() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
   const BEFORE_SIZE: Size = Size::new(50., 50.);
   const AFTER_TAP_SIZE: Size = Size::new(100., 100.);
   let w = widget! {
@@ -66,6 +72,8 @@ fn event_attr_sugar_work() {
 
 #[test]
 fn widget_wrap_bind_work() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let w = widget! {
     Flex {
       SizedBox {
@@ -93,6 +101,8 @@ fn widget_wrap_bind_work() {
 
 #[test]
 fn expression_for_children() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let size_one = Size::new(1., 1.);
   let size_five = Size::new(5., 5.);
   let embed_expr = widget! {
@@ -128,6 +138,8 @@ fn expression_for_children() {
 
 #[test]
 fn embed_widget_ref_outside() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let w = widget! {
     Flex {
       SizedBox {
@@ -152,6 +164,8 @@ fn embed_widget_ref_outside() {
 
 #[test]
 fn data_flow_macro() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let size = Size::new(1., 1.);
   let w = widget! {
     Flex {
@@ -205,6 +219,8 @@ widget_layout_test!(
 #[test]
 
 fn builtin_ref() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let icon_track = Rc::new(Cell::new(CursorIcon::default()));
   let c_icon_track = icon_track.clone();
 
@@ -233,6 +249,8 @@ fn builtin_ref() {
 
 #[test]
 fn builtin_bind_to_self() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let icon_track = Rc::new(Cell::new(CursorIcon::default()));
   let c_icon_track = icon_track.clone();
   let w = widget! {
@@ -287,6 +305,8 @@ fn tap_at(wnd: &mut TestWindow, pos: (i32, i32)) {
 
 #[test]
 fn builtin_method_support() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let layout_size = Stateful::new(Size::zero());
   let w = widget! {
     states { layout_size: layout_size.clone() }
@@ -308,6 +328,8 @@ fn builtin_method_support() {
 
 #[test]
 fn fix_builtin_field_can_declare_as_widget() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let w = widget! {
     Margin {
       margin: EdgeInsets::all(1.),
@@ -321,6 +343,8 @@ fn fix_builtin_field_can_declare_as_widget() {
 
 #[test]
 fn fix_use_builtin_field_of_builtin_widget_gen_duplicate() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let w = widget! {
     Margin {
       id: margin,
@@ -352,6 +376,8 @@ fn fix_access_builtin_with_gap() {
 
 #[test]
 fn fix_subscribe_cancel_after_widget_drop() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let notify_cnt = Stateful::new(0);
   let trigger = Stateful::new(true);
   let w = widget! {
@@ -409,6 +435,8 @@ widget_layout_test!(
 
 #[test]
 fn fix_silent_not_relayout_dyn_widget() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let trigger_size = Stateful::new(ZERO_SIZE);
   let w = widget! {
     states { trigger_size: trigger_size.clone() }
@@ -434,6 +462,8 @@ fn fix_silent_not_relayout_dyn_widget() {
 
 #[test]
 fn no_watch() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let size = Stateful::new(ZERO_SIZE);
   let w = widget! {
     states { size: size.clone() }
@@ -453,6 +483,8 @@ fn no_watch() {
 
 #[test]
 fn embed_shadow_states() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let _ = widget! {
     // variable `_a` here
     widget::from(|_a: &BuildCtx| widget! {
@@ -466,6 +498,8 @@ fn embed_shadow_states() {
 
 #[test]
 fn untrack_prop_with_pure_lambda() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let trigger = Stateful::new(0_u32);
   let counter = Stateful::new(0_u32);
   let w = widget! {
@@ -511,6 +545,8 @@ fn untrack_prop_with_pure_lambda() {
 
 #[test]
 fn embed_widget() {
+  let _guard = unsafe { AppCtx::new_lock_scope() };
+
   let _ = widget! {
     Column {
       widget! { // simple case & as first child

--- a/widgets/src/input/caret.rs
+++ b/widgets/src/input/caret.rs
@@ -24,8 +24,8 @@ impl Compose for Caret {
           box_fit: BoxFit::Fill,
         }
       }
-      finally ctx => {
-        let scheduler = ctx.wnd_ctx().scheduler();
+      finally {
+        let scheduler = AppCtx::scheduler();
         let mut _guard = None;
         let_watch!(this.focused)
           .distinct_until_changed()

--- a/widgets/src/input/handle.rs
+++ b/widgets/src/input/handle.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use ribir_core::prelude::{
-  CharsEvent, GraphemeCursor, KeyboardEvent, StateRef, TextWriter, VirtualKeyCode,
+  AppCtx, CharsEvent, GraphemeCursor, KeyboardEvent, StateRef, TextWriter, VirtualKeyCode,
 };
 
 #[macro_export]
@@ -75,7 +75,7 @@ impl TextEditorArea {
 
 fn key_with_command(this: &mut StateRef<TextEditorArea>, event: &mut KeyboardEvent) -> bool {
   if event.key == VirtualKeyCode::V && event.common.with_command_key() {
-    let clipboard = event.context().clipboard();
+    let clipboard = AppCtx::clipboard();
     let txt = clipboard.borrow_mut().read_text();
     if let Ok(txt) = txt {
       let rg = this.caret.select_range();

--- a/widgets/src/input/text_selectable.rs
+++ b/widgets/src/input/text_selectable.rs
@@ -60,7 +60,7 @@ impl ComposeChild for TextSelectable {
           on_performed_layout: move |ctx| {
             let bound = ctx.layout_info().expect("layout info must exit in performed_layout").clamp;
             this.helper.glyphs = Some(text.text_layout(
-              ctx.wnd_ctx().typography_store(),
+              AppCtx::typography_store(),
               bound.max,
             ));
             this.forget_modifies();
@@ -104,7 +104,7 @@ fn deal_with_command(
     VirtualKeyCode::C => {
       let rg = this.caret.select_range();
       if !rg.is_empty() {
-        let clipboard = event.context().clipboard();
+        let clipboard = AppCtx::clipboard();
         let _ = clipboard.borrow_mut().clear();
         let _ = clipboard.borrow_mut().write_text(&text.substr(rg));
       }

--- a/widgets/src/scrollbar.rs
+++ b/widgets/src/scrollbar.rs
@@ -260,7 +260,7 @@ impl Compose for VRawScrollbar {
           thickness,
           thumb_min_size,
           ref track_brush
-        } = *ScrollBarStyle::of(ctx);
+        } = ScrollBarStyle::of(ctx);
       }
 
       Stack {
@@ -344,6 +344,8 @@ mod test {
 
   #[test]
   fn scrollable() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let offset = Stateful::new(Point::zero());
     let v_offset = Stateful::new(0.);
     let h_offset = Stateful::new(0.);

--- a/widgets/src/text.rs
+++ b/widgets/src/text.rs
@@ -51,10 +51,9 @@ impl Text {
 }
 
 impl Render for Text {
-  fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
-    let wnd_ctx = ctx.wnd_ctx();
+  fn perform_layout(&self, clamp: BoxClamp, _: &mut LayoutCtx) -> Size {
     self
-      .text_layout(wnd_ctx.typography_store(), clamp.max)
+      .text_layout(AppCtx::typography_store(), clamp.max)
       .visual_rect()
       .size
       .cast_unit()
@@ -67,14 +66,14 @@ impl Render for Text {
   fn paint(&self, ctx: &mut PaintingCtx) {
     let bounds = ctx.layout_clamp().map(|b| b.max);
     let visual_glyphs = typography_with_text_style(
-      ctx.typography_store(),
+      AppCtx::typography_store(),
       self.text.clone(),
       &self.text_style,
       bounds,
       self.overflow,
     );
 
-    let font_db = ctx.typography_store().font_db().clone();
+    let font_db = AppCtx::font_db().clone();
     let font_size = self.text_style.font_size.into_pixel().value();
     let box_rect = Rect::from_size(ctx.box_size().unwrap());
     draw_glyphs_in_rect(
@@ -180,6 +179,8 @@ mod tests {
 
   #[test]
   fn text_clip() {
+    let _guard = unsafe { AppCtx::new_lock_scope() };
+
     let w = widget! {
       SizedBox {
         size: Size::new(50., 45.),


### PR DESCRIPTION
This pull request implements the `App` and `AppCtx` in a single instance way, so the user can use them anywhere without passing them as parameters. But also limits the global instance only to be used in a single thread. If you want to create multi instances or in multi-thread. You should use `AppCtx::new_lock_scope` to create a scope guard to ensure the global instance is only used in the scope. Enter the scope will reset the global instance and lock it until the scope is dropped.