### PR TITLE
fix(gpu): 🐛 grow the atlas may miss the overlap area

### DIFF
--- a/gpu/src/gpu_backend/textures_mgr.rs
+++ b/gpu/src/gpu_backend/textures_mgr.rs
@@ -66,7 +66,12 @@ where
   pub(super) fn new(gpu_impl: &mut T::Host, anti_aliasing: AntiAliasing) -> Self {
     Self {
       alpha_atlas: Atlas::new("Alpha atlas", ColorFormat::Alpha8, anti_aliasing, gpu_impl),
-      rgba_atlas: Atlas::new("Rgba atlas", ColorFormat::Rgba8, anti_aliasing, gpu_impl),
+      rgba_atlas: Atlas::new(
+        "Rgba atlas",
+        ColorFormat::Rgba8,
+        AntiAliasing::None,
+        gpu_impl,
+      ),
       fill_task: <_>::default(),
       fill_task_buffers: <_>::default(),
     }


### PR DESCRIPTION
When the atlas expand, we copy whole texture from the old texture, but the not allocated area may be allocated to new resource. And we not require the gpu backend implementation to keep the order of the copy and write operation on the texture. So the overlap area may be wrong. We fix this to avoid copy the area we not allocated.