### PR TITLE
fix(macros): 🐛 compile error when use `map_writer!` with builtin fiel…

### DIFF
--- a/macros/src/symbol_process.rs
+++ b/macros/src/symbol_process.rs
@@ -628,7 +628,7 @@ impl<'a> Drop for StackGuard<'a> {
 impl Default for DollarRefsCtx {
   fn default() -> Self {
     Self {
-      scopes: smallvec![DollarRefsScope::default()],
+      scopes: smallvec![],
       capture_level_heads: smallvec![],
       variable_stacks: vec![vec![]],
     }

--- a/tests/rdl_macro_test.rs
+++ b/tests/rdl_macro_test.rs
@@ -845,3 +845,11 @@ fn no_watch() {
   wnd.draw_frame();
   assert_layout_result_by_path!(wnd, { path = [0], size == ZERO_SIZE,});
 }
+
+#[test]
+fn fix_direct_use_map_writer_with_builtin() {
+  fn _x(mut host: FatObj<Void>, ctx!(): &BuildCtx) {
+    let _left = map_writer!($host.left_anchor);
+    let _left = split_writer!($host.left_anchor);
+  }
+}


### PR DESCRIPTION
…d not in `fn_widget!`