### PR TITLE
refactor(core): 💡 cancel anchor support percent unit

### DIFF
--- a/core/src/builtin_widgets/anchor.rs
+++ b/core/src/builtin_widgets/anchor.rs
@@ -1,49 +1,39 @@
 use crate::prelude::*;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PositionUnit {
-  /// Pixels
-  Pixel(f32),
-  /// Describe percent of widget self size. For example,  `Percent(10)` use in
-  /// x-axis means 10 percent of widget's width, in y-axis means 10 percent of
-  /// widget's height.
-  Percent(f32),
-}
-
 /// Widget use to anchor child constraints with the left edge of parent widget.
 #[derive(Declare, Query, SingleChild)]
 pub struct LeftAnchor {
-  #[declare(builtin, default = 0.)]
-  pub left_anchor: PositionUnit,
+  #[declare(builtin, default)]
+  pub left_anchor: f32,
 }
 
 /// Widget use to anchor child constraints with the right edge of parent widget.
 #[derive(Declare, Query, SingleChild)]
 pub struct RightAnchor {
-  #[declare(builtin, default = 0.)]
-  pub right_anchor: PositionUnit,
+  #[declare(builtin, default)]
+  pub right_anchor: f32,
 }
 
 /// Widget use to anchor child constraints with the top edge of parent widget.
 #[derive(Declare, Query, SingleChild)]
 pub struct TopAnchor {
-  #[declare(builtin, default = 0.)]
-  pub top_anchor: PositionUnit,
+  #[declare(builtin, default)]
+  pub top_anchor: f32,
 }
 
 /// Widget use to anchor child constraints with the bottom edge of parent
 /// widget.
 #[derive(Declare, Query, SingleChild)]
 pub struct BottomAnchor {
-  #[declare(builtin, default = 0.)]
-  pub bottom_anchor: PositionUnit,
+  #[declare(builtin, default)]
+  pub bottom_anchor: f32,
 }
 
 impl Render for LeftAnchor {
   fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
     let mut layouter = ctx.assert_single_child_layouter();
     let child_size = layouter.perform_widget_layout(clamp);
-    let left = self.left_anchor.abs_value(child_size.width);
+    let left = self.left_anchor;
     layouter.update_position(Point::new(left, 0.));
     Size::new((child_size.width + left).max(0.), child_size.height)
   }
@@ -59,7 +49,7 @@ impl Render for RightAnchor {
   fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
     let mut layouter = ctx.assert_single_child_layouter();
     let child_size = layouter.perform_widget_layout(clamp);
-    let right = self.right_anchor.abs_value(child_size.width);
+    let right = self.right_anchor;
     let x = clamp.max.width - child_size.width - right;
     layouter.update_position(Point::new(x, 0.));
 
@@ -77,7 +67,7 @@ impl Render for TopAnchor {
   fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
     let mut layouter = ctx.assert_single_child_layouter();
     let child_size = layouter.perform_widget_layout(clamp);
-    let top = self.top_anchor.abs_value(child_size.height);
+    let top = self.top_anchor;
     layouter.update_position(Point::new(0., top));
     Size::new(child_size.width, (child_size.height + top).max(0.))
   }
@@ -93,7 +83,7 @@ impl Render for BottomAnchor {
   fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
     let mut layouter = ctx.assert_single_child_layouter();
     let child_size = layouter.perform_widget_layout(clamp);
-    let bottom = self.bottom_anchor.abs_value(child_size.height);
+    let bottom = self.bottom_anchor;
     let y = clamp.max.height - child_size.height - bottom;
     layouter.update_position(Point::new(0., y));
     Size::new(child_size.width, (child_size.height + y).max(0.))
@@ -105,33 +95,11 @@ impl Render for BottomAnchor {
     HitTest { hit: false, can_hit_child: true }
   }
 }
-
-impl From<f32> for PositionUnit {
-  #[inline]
-  fn from(v: f32) -> Self { PositionUnit::Pixel(v) }
-}
-
-impl PositionUnit {
-  pub fn abs_value(self, self_size: f32) -> f32 {
-    match self {
-      PositionUnit::Pixel(pixel) => pixel,
-      PositionUnit::Percent(factor) => self_size * factor / 100.,
-    }
-  }
-
-  pub fn lerp(from: &Self, to: &Self, rate: f32, self_size: f32) -> PositionUnit {
-    let from = from.abs_value(self_size);
-    let to = to.abs_value(self_size);
-    PositionUnit::Pixel(from.lerp(&to, rate))
-  }
-}
-
 #[cfg(test)]
 mod test {
   use super::*;
   use crate::test_helper::*;
   use ribir_dev_helper::*;
-  use PositionUnit::*;
   const CHILD_SIZE: Size = Size::new(50., 50.);
   const WND_SIZE: Size = Size::new(100., 100.);
 
@@ -197,69 +165,5 @@ mod test {
     wnd_size = WND_SIZE,
     { path = [0, 0], y == 49.,}
     { path = [0, 0, 0], x== 49.,}
-  );
-
-  fn percent_left_top() -> impl WidgetBuilder {
-    fn_widget! {
-      @MockBox {
-        size: CHILD_SIZE,
-        left_anchor: Percent(10.),
-        top_anchor: Percent(10.),
-      }
-    }
-  }
-  widget_layout_test!(
-    percent_left_top,
-    wnd_size = WND_SIZE,
-    { path = [0, 0], y == 5., }
-    { path = [0, 0, 0], x == 5.,}
-  );
-
-  fn percent_left_bottom() -> impl WidgetBuilder {
-    fn_widget! {
-      @MockBox {
-        size: CHILD_SIZE,
-        left_anchor: Percent( 10.),
-        bottom_anchor: Percent( 10.),
-      }
-    }
-  }
-  widget_layout_test! {
-    percent_left_bottom,
-    wnd_size = WND_SIZE,
-    { path = [0, 0], y == 45., }
-    { path = [0, 0, 0], x == 5., }
-  }
-
-  fn percent_top_right() -> impl WidgetBuilder {
-    fn_widget! {
-      @MockBox {
-        size: CHILD_SIZE,
-        right_anchor: Percent(10.),
-        top_anchor: Percent(10.),
-      }
-    }
-  }
-  widget_layout_test!(
-    percent_top_right,
-    wnd_size = WND_SIZE,
-    { path = [0, 0], y == 5., }
-    { path = [0, 0, 0],  x == 45.,}
-  );
-
-  fn percent_bottom_right() -> impl WidgetBuilder {
-    fn_widget! {
-      @MockBox {
-        size: CHILD_SIZE,
-        right_anchor: Percent(10.),
-        bottom_anchor: Percent(10.),
-      }
-    }
-  }
-  widget_layout_test!(
-    percent_bottom_right,
-    wnd_size = WND_SIZE,
-    { path = [0, 0], y == 45.,}
-    { path = [0, 0, 0], x == 45.,}
   );
 }

--- a/themes/material/src/lib.rs
+++ b/themes/material/src/lib.rs
@@ -269,12 +269,8 @@ fn override_compose_decorator(theme: &mut FullTheme) {
       let host = scrollbar_thumb(host, EdgeInsets::vertical(1.));
       let mut thumb = @ $host { left_anchor: pipe!($this.offset) };
 
-      let left_trans = map_writer!($thumb.left_anchor);
-      left_trans.transition_with(
-        transitions::LINEAR.of(ctx!()),
-        move |from, to, rate| PositionUnit::lerp(from, to, rate, $thumb.layout_width()),
-        ctx!()
-      );
+      map_writer!($thumb.left_anchor)
+        .transition(transitions::LINEAR.of(ctx!()), ctx!());
 
       thumb
     }
@@ -285,12 +281,8 @@ fn override_compose_decorator(theme: &mut FullTheme) {
       let host = scrollbar_thumb(host, EdgeInsets::vertical(1.));
       let mut thumb = @ $host { top_anchor: pipe!($this.offset) };
 
-      let top_trans = map_writer!($thumb.top_anchor);
-      top_trans.transition_with(
-        transitions::LINEAR.of(ctx!()),
-        move |from, to, rate| PositionUnit::lerp(from, to, rate, $thumb.layout_height()),
-        ctx!()
-      );
+      map_writer!($thumb.top_anchor)
+        .transition(transitions::LINEAR.of(ctx!()), ctx!());
 
       thumb
     }
@@ -322,21 +314,12 @@ fn override_compose_decorator(theme: &mut FullTheme) {
       let ease_in = transitions::EASE_IN.of(ctx!());
       match $style.pos {
         Position::Top | Position::Bottom => {
-          let left = map_writer!($indicator.left_anchor);
-          left.transition_with(
-            ease_in,
-            move |from, to, rate| PositionUnit::lerp(from, to, rate, $style.rect.width()),
-            ctx!()
-          );
-
+          map_writer!($indicator.left_anchor)
+            .transition(ease_in, ctx!());
         }
         Position::Left | Position::Right => {
-          let top = map_writer!($indicator.top_anchor);
-          top.transition_with(
-            ease_in,
-            move |from, to, rate| PositionUnit::lerp(from, to, rate, $style.rect.height()),
-            ctx!()
-          );
+          map_writer!($indicator.top_anchor)
+            .transition(ease_in, ctx!());
         }
       }
 

--- a/widgets/src/input/editarea.rs
+++ b/widgets/src/input/editarea.rs
@@ -49,7 +49,7 @@ impl ComposeChild for TextEditorArea {
       };
 
       let scrollable = container.get_builtin_scrollable_widget(ctx!());
-      watch!(Point::new($caret.left_anchor.abs_value(1.), $caret.top_anchor.abs_value(1.)))
+      watch!(Point::new($caret.left_anchor, $caret.top_anchor))
         .scan_initial((Point::zero(), Point::zero()), |pair, v| (pair.1, v))
         .subscribe(move |(before, after)| {
           let mut scrollable = $scrollable.silent();
@@ -76,8 +76,8 @@ impl ComposeChild for TextEditorArea {
         .sample(tick_of_layout_ready)
         .subscribe(move |_| {
           let (offset, height) = $selectable.cursor_layout();
-          $caret.write().top_anchor = PositionUnit::Pixel(offset.y);
-          $caret.write().left_anchor = PositionUnit::Pixel(offset.x);
+          $caret.write().top_anchor = offset.y;
+          $caret.write().left_anchor = offset.x;
           $caret.write().height = height;
         });
 


### PR DESCRIPTION
because user can use `pipe!` to do same thing in a easy way.