### PR TITLE
refactor(core): 💡 remove unused APIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## Breaking
 
+- **core**: removed `Stateful::on_state_drop` and `Stateful::unsubscribe_on_drop` (#539 @M-Adoo)
+- **core**: removed `AppCtx::add_trigger_task` and `AppCtx::trigger_task` (#539 @M-Adoo)
 - **core**: removed `FatObj::unzip` and `FatObj::from_host` (#535 @M-Adoo)
 - **core**: removed `BuiltinObj`. (#535 @M-Adoo)
 - **core**: `FatObj::new(host: T, builtin: BuiltinObj)` -> `FatObj::new(host: T)`

--- a/tests/rdl_macro_test.rs
+++ b/tests/rdl_macro_test.rs
@@ -731,9 +731,9 @@ fn fix_subscribe_cancel_after_widget_drop() {
   let trigger = Stateful::new(true);
   let c_trigger = trigger.clone_reader();
   let w = fn_widget! {
-    let container = @SizedBox { size: Size::zero() };
+    let mut container = @SizedBox { size: Size::zero() };
     let h = watch!(*$c_trigger).subscribe(move |_| *$cnt.write() +=1 );
-    container.as_stateful().unsubscribe_on_drop(h);
+    container = container.on_disposed(move |_| h.unsubscribe());
 
     @$container {
       @ {

--- a/widgets/src/text_field.rs
+++ b/widgets/src/text_field.rs
@@ -360,7 +360,7 @@ fn build_input_area(
       .distinct_until_changed()
       .filter(|state| state == &TextFieldState::Focused)
       .subscribe(move |_| $input.request_focus());
-    input.as_stateful().unsubscribe_on_drop(h);
+    input = input.on_disposed(move|_| h.unsubscribe());
 
     @Row {
       @{


### PR DESCRIPTION
With the export of `FatObj::on_disposed`, the `on_state_drop` method, which was not particularly useful for unsubscribing the state, is no longer needed.

## Purpose of this Pull Request

 With the export of `FatObj::on_disposed`, the `on_state_drop` method, which was not particularly useful for unsubscribing the state, is no longer needed.

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.