### PR TITLE
refactor(core): 💡 simpler names for declare APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## [@Unreleased] - @ReleaseDate
 
+### Breaking
+
+_ **core**: rename `Declare::declare_builder` to `Declare::declarer` (#545 @M-Adoo)
+- **core**: rename `DeclareBuilder` to `ObjDeclarer` (#545 @M-Adoo)
+- **core**: rename `DeclareBuilder::build_declare` to `ObjDeclarer::finish` (#545 @M-Adoo)
+
 ## [0.2.0-alpha.6] - 2024-03-12
 
 ### Features
@@ -34,13 +40,13 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
     .margin(EdgeInsets::all(1.0))
     .on_click(|_, _| { println!("click"); });
   ```
-- **macros**: `#[derive(Decalre)]` now generates a `FatObj<State<T>>` instead of `State<T>`, and supports initialization of all built-in widgets on its DeclareBuilder. (#535 @M-Adoo) 
+- **macros**: `#[derive(Decalre)]` now generates a `FatObj<State<T>>` instead of `State<T>`, and supports initialization of all built-in widgets on its ObjBuilder. (#535 @M-Adoo) 
   All pipes used to initialize the field will be unsubscribed when the FatObj is disposed.
   ```rust
-  let row = Row::declare_builder()
+  let row = Row::builder()
     .margin(...)
     .on_click(...)
-    .build_declare(ctx);
+    .finish(ctx);
   ```
 - **macros**: Introduced `simple_declare` macro for types that don't use `Pipe` for initialization. (#535 @M-Adoo)
 

--- a/core/src/animation/transition.rs
+++ b/core/src/animation/transition.rs
@@ -32,11 +32,11 @@ pub trait TransitionState: Sized + 'static {
     Self: AnimateState,
   {
     let state = self.clone_setter();
-    let animate = Animate::declare_builder()
+    let animate = Animate::declarer()
       .transition(transition)
       .from(self.get())
       .state(self)
-      .build_declare(ctx);
+      .finish(ctx);
 
     let c_animate = animate.clone_writer();
     let init_value = observable::of(state.get());

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -978,10 +978,10 @@ impl<T> FatObj<T> {
   }
 }
 
-impl<T> DeclareBuilder for FatObj<T> {
+impl<T> ObjDeclarer for FatObj<T> {
   type Target = Self;
 
-  fn build_declare(self, _: &BuildCtx) -> Self::Target { self }
+  fn finish(self, _: &BuildCtx) -> Self::Target { self }
 }
 
 impl<T: SingleChild> SingleChild for FatObj<T> {}

--- a/core/src/builtin_widgets/align.rs
+++ b/core/src/builtin_widgets/align.rs
@@ -68,13 +68,13 @@ pub struct VAlignWidget {
 impl Declare for HAlignWidget {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Declare for VAlignWidget {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Render for HAlignWidget {

--- a/core/src/builtin_widgets/anchor.rs
+++ b/core/src/builtin_widgets/anchor.rs
@@ -163,7 +163,7 @@ pub struct RelativeAnchor {
 impl Declare for RelativeAnchor {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Render for RelativeAnchor {

--- a/core/src/builtin_widgets/box_decoration.rs
+++ b/core/src/builtin_widgets/box_decoration.rs
@@ -15,7 +15,7 @@ pub struct BoxDecoration {
 impl Declare for BoxDecoration {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -200,7 +200,7 @@ mod tests {
     let dummy = std::mem::MaybeUninit::uninit();
     // just for test, we know BoxDecoration not use `ctx` to build.
     let ctx: BuildCtx<'static> = unsafe { dummy.assume_init() };
-    let mut w = BoxDecoration::declare_builder().build_declare(&ctx);
+    let mut w = BoxDecoration::declarer().finish(&ctx);
     let w = w.get_box_decoration_widget();
 
     assert_eq!(w.read().border, None);

--- a/core/src/builtin_widgets/cursor.rs
+++ b/core/src/builtin_widgets/cursor.rs
@@ -11,7 +11,7 @@ pub struct Cursor {
 impl Declare for Cursor {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for Cursor {

--- a/core/src/builtin_widgets/delay_drop.rs
+++ b/core/src/builtin_widgets/delay_drop.rs
@@ -20,7 +20,7 @@ pub struct DelayDrop {
 impl Declare for DelayDrop {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for DelayDrop {

--- a/core/src/builtin_widgets/fitted_box.rs
+++ b/core/src/builtin_widgets/fitted_box.rs
@@ -38,7 +38,7 @@ pub struct FittedBox {
 impl Declare for FittedBox {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl FittedBox {

--- a/core/src/builtin_widgets/focus_node.rs
+++ b/core/src/builtin_widgets/focus_node.rs
@@ -8,7 +8,7 @@ pub struct RequestFocus {
 impl Declare for RequestFocus {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for RequestFocus {

--- a/core/src/builtin_widgets/global_anchor.rs
+++ b/core/src/builtin_widgets/global_anchor.rs
@@ -9,7 +9,7 @@ pub struct GlobalAnchor {
 impl Declare for GlobalAnchor {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for GlobalAnchor {

--- a/core/src/builtin_widgets/has_focus.rs
+++ b/core/src/builtin_widgets/has_focus.rs
@@ -11,7 +11,7 @@ impl HasFocus {
 impl Declare for HasFocus {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for HasFocus {

--- a/core/src/builtin_widgets/layout_box.rs
+++ b/core/src/builtin_widgets/layout_box.rs
@@ -10,7 +10,7 @@ pub struct LayoutBox {
 impl Declare for LayoutBox {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for LayoutBox {

--- a/core/src/builtin_widgets/margin.rs
+++ b/core/src/builtin_widgets/margin.rs
@@ -17,7 +17,7 @@ pub struct Margin {
 impl Declare for Margin {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Render for Margin {

--- a/core/src/builtin_widgets/mix_builtin.rs
+++ b/core/src/builtin_widgets/mix_builtin.rs
@@ -53,7 +53,7 @@ pub struct MixBuiltin {
 impl Declare for MixBuiltin {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 macro_rules! event_map_filter {

--- a/core/src/builtin_widgets/mouse_hover.rs
+++ b/core/src/builtin_widgets/mouse_hover.rs
@@ -12,7 +12,7 @@ impl MouseHover {
 impl Declare for MouseHover {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for MouseHover {

--- a/core/src/builtin_widgets/opacity.rs
+++ b/core/src/builtin_widgets/opacity.rs
@@ -8,7 +8,7 @@ pub struct Opacity {
 impl Declare for Opacity {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Default for Opacity {

--- a/core/src/builtin_widgets/padding.rs
+++ b/core/src/builtin_widgets/padding.rs
@@ -9,7 +9,7 @@ pub struct Padding {
 impl Declare for Padding {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Render for Padding {

--- a/core/src/builtin_widgets/pointer_pressed.rs
+++ b/core/src/builtin_widgets/pointer_pressed.rs
@@ -10,7 +10,7 @@ pub struct PointerPressed {
 impl Declare for PointerPressed {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl PointerPressed {

--- a/core/src/builtin_widgets/scrollable.rs
+++ b/core/src/builtin_widgets/scrollable.rs
@@ -26,7 +26,7 @@ pub struct ScrollableWidget {
 impl Declare for ScrollableWidget {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for ScrollableWidget {

--- a/core/src/builtin_widgets/transform_widget.rs
+++ b/core/src/builtin_widgets/transform_widget.rs
@@ -8,7 +8,7 @@ pub struct TransformWidget {
 impl Declare for TransformWidget {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl Render for TransformWidget {

--- a/core/src/builtin_widgets/visibility.rs
+++ b/core/src/builtin_widgets/visibility.rs
@@ -8,7 +8,7 @@ pub struct Visibility {
 impl Declare for Visibility {
   type Builder = FatObj<()>;
   #[inline]
-  fn declare_builder() -> Self::Builder { FatObj::new(()) }
+  fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
 impl ComposeChild for Visibility {

--- a/core/src/declare.rs
+++ b/core/src/declare.rs
@@ -2,20 +2,19 @@ use crate::{context::BuildCtx, pipe::Pipe, prelude::BoxPipe, state::ModifyScope}
 use rxrust::ops::box_it::BoxOp;
 use std::convert::Infallible;
 
-/// The next version of `Declare` trait. It will replace the `Declare` trait
-/// after it is stable.
+/// Trait used to create a widget declarer that can interact with the `BuildCtx`
+/// to create a widget.
 pub trait Declare {
-  type Builder: DeclareBuilder;
-  fn declare_builder() -> Self::Builder;
+  type Builder: ObjDeclarer;
+  fn declarer() -> Self::Builder;
 }
 
-/// widget builder use to construct a widget in  `widget!`. See the [mod level
-/// document](declare) to know how to use it.
-pub trait DeclareBuilder {
+/// An object declarer is a type that can be used to create a object with the
+/// given context.
+pub trait ObjDeclarer {
   type Target;
-  /// build the object with the given context, return the object and not care
-  /// about if this object is subscribed to other or not.
-  fn build_declare(self, ctx: &BuildCtx) -> Self::Target;
+  /// Finish the object creation with the given context.
+  fn finish(self, ctx: &BuildCtx) -> Self::Target;
 }
 
 /// The type use to store the init value of the field when declare a object.

--- a/macros/src/child_template.rs
+++ b/macros/src/child_template.rs
@@ -59,13 +59,13 @@ pub(crate) fn derive_child_template(input: &mut syn::DeriveInput) -> syn::Result
         impl #g_impl Declare for #name #g_ty #g_where {
           type Builder = #builder #g_ty;
           #[inline]
-          fn declare_builder() -> Self::Builder { #name::builder() }
+          fn declarer() -> Self::Builder { #name::builder() }
         }
 
-        impl #g_impl DeclareBuilder for #builder #g_ty {
+        impl #g_impl ObjDeclarer for #builder #g_ty {
           type Target = Self;
           #[inline]
-          fn build_declare(self, _: &BuildCtx) -> Self { self }
+          fn finish(self, _: &BuildCtx) -> Self { self }
         }
 
 

--- a/macros/src/declare_derive.rs
+++ b/macros/src/declare_derive.rs
@@ -41,7 +41,7 @@ pub(crate) fn declare_derive(input: &mut syn::DeriveInput) -> syn::Result<TokenS
       impl #g_impl Declare for #host #g_ty #g_where {
         type Builder = #name #g_ty;
 
-        fn declare_builder() -> Self::Builder {
+        fn declarer() -> Self::Builder {
           #name {
             #(#builder_f_names : None ,)*
             fat_obj: FatObj::new(()),
@@ -49,12 +49,12 @@ pub(crate) fn declare_derive(input: &mut syn::DeriveInput) -> syn::Result<TokenS
         }
       }
 
-      impl #g_impl DeclareBuilder for #name #g_ty #g_where {
+      impl #g_impl ObjDeclarer for #name #g_ty #g_where {
         #[allow(clippy::type_complexity)]
         type Target = FatObj<State<#host #g_ty>>;
 
         #[inline]
-        fn build_declare(mut self, ctx!(): &BuildCtx) -> Self::Target {
+        fn finish(mut self, ctx!(): &BuildCtx) -> Self::Target {
           #(#field_values)*
           let mut _this_ಠ_ಠ = State::value(#host {
             #(#field_names : #field_names.0),*
@@ -673,7 +673,7 @@ fn empty_impl(name: &Ident, fields: &Fields) -> syn::Result<TokenStream> {
   let tokens = quote! {
     impl Declare for #name  {
       type Builder = FatObj<#name>;
-      fn declare_builder() -> Self::Builder { FatObj::new(#construct) }
+      fn declarer() -> Self::Builder { FatObj::new(#construct) }
     }
   };
   Ok(tokens)

--- a/macros/src/declare_obj.rs
+++ b/macros/src/declare_obj.rs
@@ -84,19 +84,19 @@ impl<'a> DeclareObj<'a> {
     match node_type {
       ObjType::Type { ty, span } => {
         if fields.is_empty() {
-          quote_spanned! { *span => #ty::declare_builder().build_declare(ctx!())}.to_tokens(tokens);
+          quote_spanned! { *span => #ty::declarer().finish(ctx!())}.to_tokens(tokens);
         } else {
           let fields = fields.iter();
           // we not gen chain call to avoid borrow twice. e.g.
           // ```
           // let mut x = ...;
-          // X::declare_builder().a(&mut x.a).b(&mut x.b).build_declare(ctx!());
+          // X::declarer().a(&mut x.a).b(&mut x.b).finish(ctx!());
           // ```
           // `x` will be borrowed twice, and compile failed, rustc don't process it.
           quote_spanned! { *span => {
-            let mut _ಠ_ಠ = #ty::declare_builder();
+            let mut _ಠ_ಠ = #ty::declarer();
             #(_ಠ_ಠ = _ಠ_ಠ #fields;)*
-            _ಠ_ಠ.build_declare(ctx!())
+            _ಠ_ಠ.finish(ctx!())
           }}
           .to_tokens(tokens);
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -115,7 +115,7 @@ pub fn lerp_derive(input: TokenStream) -> TokenStream {
 /// widget, then
 ///
 /// - implement `Declare` for `XXX`  mark `XXXBuilder` as its builder type.
-/// - implement `DeclareBuilder` for `XXXBuilder` which build `XXX` and used by
+/// - implement `ObjDeclarer` for `XXXBuilder` which build `XXX` and used by
 ///   `declare!` to build the `XXX` widget.
 /// - for every field of `XXXBuilder`
 ///   - implement method with same name of the field and use to init the field.

--- a/macros/src/simple_declare_attr.rs
+++ b/macros/src/simple_declare_attr.rs
@@ -35,16 +35,16 @@ pub(crate) fn simple_declarer_attr(stt: &mut syn::ItemStruct) -> Result<TokenStr
     impl #g_impl Declare for #ident #g_ty #g_where {
       type Builder = #name #g_ty;
 
-      fn declare_builder() -> Self::Builder {
+      fn declarer() -> Self::Builder {
         #name { #(#builder_f_names : None ),*}
       }
     }
 
-    impl #g_impl DeclareBuilder for #name #g_ty #g_where {
+    impl #g_impl ObjDeclarer for #name #g_ty #g_where {
       type Target = State<#ident #g_ty>;
 
       #[inline]
-      fn build_declare(mut self, ctx!(): &BuildCtx) -> Self::Target {
+      fn finish(mut self, ctx!(): &BuildCtx) -> Self::Target {
         State::value(#ident {#(#init_pairs),*})
       }
     }
@@ -70,13 +70,13 @@ fn empty_impl(stt: &syn::ItemStruct) -> Result<TokenStream> {
 
     impl Declare for #name  {
       type Builder = #name;
-      fn declare_builder() -> Self::Builder { #construct }
+      fn declarer() -> Self::Builder { #construct }
     }
 
-    impl DeclareBuilder for #name {
+    impl ObjDeclarer for #name {
       type Target = #name;
       #[inline]
-      fn build_declare(self, _: &BuildCtx) -> Self::Target { self }
+      fn finish(self, _: &BuildCtx) -> Self::Target { self }
     }
   };
   Ok(tokens)

--- a/tests/declare_builder_test.rs
+++ b/tests/declare_builder_test.rs
@@ -3,12 +3,12 @@ use ribir::prelude::*;
 fn dummy_ctx() -> &'static BuildCtx<'static> { unsafe { std::mem::transmute(&0) } }
 
 #[test]
-fn declare_builder_smoke() {
+fn declarer_smoke() {
   // empty struct
   #[derive(Declare)]
   struct A;
 
-  let _: FatObj<A> = A::declare_builder().build_declare(dummy_ctx());
+  let _: FatObj<A> = A::declarer().finish(dummy_ctx());
 
   #[derive(Declare)]
   struct B {
@@ -16,10 +16,7 @@ fn declare_builder_smoke() {
     b: i32,
   }
 
-  let b = <B as Declare>::declare_builder()
-    .a(1.)
-    .b(1)
-    .build_declare(dummy_ctx());
+  let b = <B as Declare>::declarer().a(1.).b(1).finish(dummy_ctx());
   assert_eq!(b.read().a, 1.);
   assert_eq!(b.read().b, 1);
 }
@@ -32,7 +29,7 @@ fn panic_if_miss_require_field() {
     _a: f32,
   }
 
-  let _ = <T as Declare>::declare_builder().build_declare(dummy_ctx());
+  let _ = <T as Declare>::declarer().finish(dummy_ctx());
 }
 
 #[test]
@@ -44,7 +41,7 @@ fn default_field() {
     a: f32,
   }
 
-  let t = <DefaultDeclare as Declare>::declare_builder().build_declare(dummy_ctx());
+  let t = <DefaultDeclare as Declare>::declarer().finish(dummy_ctx());
   assert_eq!(t.read().a, 0.);
 }
 
@@ -57,7 +54,7 @@ fn default_field_with_value() {
     text: &'static str,
   }
 
-  let t = <DefaultWithValue as Declare>::declare_builder().build_declare(dummy_ctx());
+  let t = <DefaultWithValue as Declare>::declarer().finish(dummy_ctx());
   assert_eq!(t.read().text, "hi!");
 }
 
@@ -69,10 +66,7 @@ fn declarer_simple_attr() {
     b: i32,
   }
 
-  let s = Simple::declare_builder()
-    .a(1.)
-    .b(1)
-    .build_declare(dummy_ctx());
+  let s = Simple::declarer().a(1.).b(1).finish(dummy_ctx());
   assert_eq!(s.read().a, 1.);
   assert_eq!(s.read().b, 1);
 }

--- a/widgets/src/layout/flex.rs
+++ b/widgets/src/layout/flex.rs
@@ -63,12 +63,12 @@ pub struct Column;
 
 impl Declare for Row {
   type Builder = FlexDeclarer;
-  fn declare_builder() -> Self::Builder { Flex::declare_builder().direction(Direction::Horizontal) }
+  fn declarer() -> Self::Builder { Flex::declarer().direction(Direction::Horizontal) }
 }
 
 impl Declare for Column {
   type Builder = FlexDeclarer;
-  fn declare_builder() -> Self::Builder { Flex::declare_builder().direction(Direction::Vertical) }
+  fn declarer() -> Self::Builder { Flex::declarer().direction(Direction::Vertical) }
 }
 
 impl Render for Flex {


### PR DESCRIPTION
## Purpose of this Pull Request

Simplify the names of the declare-related APIs

- `Declare::declare_builder` to `Declare::declarer`, 
- `DeclareBuilder` to `ObjDeclarer`, 
- `DeclareBuilder::build_declare` to `ObjDeclarer::finish`

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.