### PR TITLE
refactor(core): 💡 Renamed the `widget_build` method to `build` for br…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ## [@Unreleased] - @ReleaseDate
 
 ### Documented
-
 - **Ribir**: Added a roadmap. (#550, @M-Adoo)
+
+### Breaking 
+- **core**: Renamed the `widget_build` method to `build` for brevity, given its frequent usage. (#549 @M-Adoo)
 
 
 ## [0.2.0-alpha.7] - 2024-03-19
@@ -135,7 +137,7 @@ We are very happy to share it with you. We hope you can try it out and give us f
 - **GPU render**: GPU backend for the **painter**, do path tessellation, so that easy to render the triangles in any GPU render engine. A `wgpu` implementation is provided as the default GPU render engine. Tessellation base on [lyon](https://github.com/nical/lyon).
 - **text**: support basic text typography and IME input, in a usable but rough stage.
 - **widgets**: the widgets library provides 20+ basic widgets, but all are in a rough stage, and the API is not stable yet.
-- **examples**: counter, storybook, messages, todos, wordle\_game, etc.
+- **examples**: counter, storybook, messages, todos, wordle_game, etc.
 
 ### Documented
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
       .finish(ctx)
       .with_child(inc_btn, ctx)
       .with_child(counter, ctx)
-      .widget_build(ctx)
+      .build(ctx)
   };
 }
 ```

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -100,7 +100,7 @@ pub struct LazyWidgetId(Sc<Cell<Option<WidgetId>>>);
 ///   let w = multi.get_margin_widget().clone_writer();
 ///   multi
 ///     .on_tap(move |_| w.write().margin = EdgeInsets::all(20.))
-///     .widget_build(ctx)
+///     .build(ctx)
 /// };
 /// ```
 pub struct FatObj<T> {
@@ -989,76 +989,76 @@ impl<T: MultiChild> MultiChild for FatObj<T> {}
 
 crate::widget::multi_build_replace_impl! {
   impl<T: {#} > {#} for FatObj<T> {
-    fn widget_build(self, ctx: &BuildCtx) -> Widget {
-      self.map(|host| host.widget_build(ctx)).widget_build(ctx)
+    fn build(self, ctx: &BuildCtx) -> Widget {
+      self.map(|host| host.build(ctx)).build(ctx)
     }
   }
 }
 
 impl WidgetBuilder for FatObj<Widget> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     let mut host = self.host;
     self.host_id.set(host.id());
     if let Some(mix_builtin) = self.mix_builtin {
-      host = mix_builtin.with_child(host, ctx).widget_build(ctx)
+      host = mix_builtin.with_child(host, ctx).build(ctx)
     }
     if let Some(request_focus) = self.request_focus {
-      host = request_focus.with_child(host, ctx).widget_build(ctx);
+      host = request_focus.with_child(host, ctx).build(ctx);
     }
     if let Some(has_focus) = self.has_focus {
-      host = has_focus.with_child(host, ctx).widget_build(ctx);
+      host = has_focus.with_child(host, ctx).build(ctx);
     }
     if let Some(mouse_hover) = self.mouse_hover {
-      host = mouse_hover.with_child(host, ctx).widget_build(ctx);
+      host = mouse_hover.with_child(host, ctx).build(ctx);
     }
     if let Some(pointer_pressed) = self.pointer_pressed {
-      host = pointer_pressed.with_child(host, ctx).widget_build(ctx);
+      host = pointer_pressed.with_child(host, ctx).build(ctx);
     }
     if let Some(fitted_box) = self.fitted_box {
-      host = fitted_box.with_child(host, ctx).widget_build(ctx);
+      host = fitted_box.with_child(host, ctx).build(ctx);
     }
     if let Some(box_decoration) = self.box_decoration {
-      host = box_decoration.with_child(host, ctx).widget_build(ctx);
+      host = box_decoration.with_child(host, ctx).build(ctx);
     }
     if let Some(padding) = self.padding {
-      host = padding.with_child(host, ctx).widget_build(ctx);
+      host = padding.with_child(host, ctx).build(ctx);
     }
     if let Some(layout_box) = self.layout_box {
-      host = layout_box.with_child(host, ctx).widget_build(ctx);
+      host = layout_box.with_child(host, ctx).build(ctx);
     }
     if let Some(cursor) = self.cursor {
-      host = cursor.with_child(host, ctx).widget_build(ctx);
+      host = cursor.with_child(host, ctx).build(ctx);
     }
     if let Some(margin) = self.margin {
-      host = margin.with_child(host, ctx).widget_build(ctx);
+      host = margin.with_child(host, ctx).build(ctx);
     }
     if let Some(scrollable) = self.scrollable {
-      host = scrollable.with_child(host, ctx).widget_build(ctx);
+      host = scrollable.with_child(host, ctx).build(ctx);
     }
     if let Some(transform) = self.transform {
-      host = transform.with_child(host, ctx).widget_build(ctx);
+      host = transform.with_child(host, ctx).build(ctx);
     }
     if let Some(h_align) = self.h_align {
-      host = h_align.with_child(host, ctx).widget_build(ctx);
+      host = h_align.with_child(host, ctx).build(ctx);
     }
     if let Some(v_align) = self.v_align {
-      host = v_align.with_child(host, ctx).widget_build(ctx);
+      host = v_align.with_child(host, ctx).build(ctx);
     }
     if let Some(relative_anchor) = self.relative_anchor {
-      host = relative_anchor.with_child(host, ctx).widget_build(ctx);
+      host = relative_anchor.with_child(host, ctx).build(ctx);
     }
     if let Some(global_anchor) = self.global_anchor {
-      host = global_anchor.with_child(host, ctx).widget_build(ctx);
+      host = global_anchor.with_child(host, ctx).build(ctx);
     }
     if let Some(visibility) = self.visibility {
-      host = visibility.with_child(host, ctx).widget_build(ctx);
+      host = visibility.with_child(host, ctx).build(ctx);
     }
     if let Some(opacity) = self.opacity {
-      host = opacity.with_child(host, ctx).widget_build(ctx);
+      host = opacity.with_child(host, ctx).build(ctx);
     }
     if let Some(delay_drop) = self.delay_drop {
-      host = delay_drop.with_child(host, ctx).widget_build(ctx);
+      host = delay_drop.with_child(host, ctx).build(ctx);
     }
     if let Some(h) = self.delay_drop_unsubscribe_handle {
       let arena = &mut ctx.tree.borrow_mut().arena;
@@ -1094,9 +1094,7 @@ impl<T: PairWithChild<C>, C> PairWithChild<C> for FatObj<T> {
 
 impl<T: SingleParent + 'static> SingleParent for FatObj<T> {
   fn compose_child(self, child: Widget, ctx: &BuildCtx) -> Widget {
-    self
-      .map(|host| host.compose_child(child, ctx))
-      .widget_build(ctx)
+    self.map(|host| host.compose_child(child, ctx)).build(ctx)
   }
 }
 
@@ -1104,7 +1102,7 @@ impl<T: MultiParent + 'static> MultiParent for FatObj<T> {
   fn compose_children(self, children: impl Iterator<Item = Widget>, ctx: &BuildCtx) -> Widget {
     self
       .map(|host| host.compose_children(children, ctx))
-      .widget_build(ctx)
+      .build(ctx)
   }
 }
 

--- a/core/src/builtin_widgets/delay_drop.rs
+++ b/core/src/builtin_widgets/delay_drop.rs
@@ -52,11 +52,11 @@ mod tests {
     let mut wnd = TestWindow::new(fn_widget! {
       pipe! {
         if *$remove_widget {
-          Void.widget_build(ctx!())
+          Void.build(ctx!())
         } else {
           FatObj::new(Void)
             .delay_drop_until(pipe!(*$delay_drop))
-            .widget_build(ctx!())
+            .build(ctx!())
         }
       }
     });

--- a/core/src/builtin_widgets/focus_node.rs
+++ b/core/src/builtin_widgets/focus_node.rs
@@ -21,7 +21,7 @@ impl ComposeChild for RequestFocus {
           $this.silent().handle = Some(handle);
         }
       }
-      .widget_build(ctx!())
+      .build(ctx!())
       .attach_state_data(this, ctx!())
     }
   }

--- a/core/src/builtin_widgets/focus_scope.rs
+++ b/core/src/builtin_widgets/focus_scope.rs
@@ -22,7 +22,7 @@ impl ComposeChild for FocusScope {
         on_mounted: move |e| e.window().add_focus_node(e.id, false, FocusType::Scope),
         on_disposed: move|e| e.window().remove_focus_node(e.id, FocusType::Scope),
       }
-      .widget_build(ctx!())
+      .build(ctx!())
       .attach_state_data(this, ctx!())
     }
   }

--- a/core/src/builtin_widgets/global_anchor.rs
+++ b/core/src/builtin_widgets/global_anchor.rs
@@ -45,7 +45,7 @@ impl ComposeChild for GlobalAnchor {
             $child.write().anchor = anchor;
           }
         });
-      child.widget_build(ctx!())
+      child.build(ctx!())
     }
   }
 }

--- a/core/src/builtin_widgets/key.rs
+++ b/core/src/builtin_widgets/key.rs
@@ -124,7 +124,7 @@ impl<V: 'static + Default + Clone + PartialEq> ComposeChild for KeyWidget<V> {
   fn compose_child(this: impl StateWriter<Value = Self>, child: Self::Child) -> impl WidgetBuilder {
     fn_widget! {
       let data: Box<dyn AnyKey> = Box::new(this);
-      child.attach_data(data, ctx!()).widget_build(ctx!())
+      child.attach_data(data, ctx!()).build(ctx!())
     }
   }
 }

--- a/core/src/builtin_widgets/theme.rs
+++ b/core/src/builtin_widgets/theme.rs
@@ -94,7 +94,7 @@ impl ComposeChild for ThemeWidget {
       // node, because the subtree may be hold its id.
       //
       // A `Void` is cheap for a theme.
-      let p = Void.widget_build(ctx!()).attach_data(theme, ctx!());
+      let p = Void.build(ctx!()).attach_data(theme, ctx!());
       // shadow the context with the theme.
       let ctx = BuildCtx::new_with_data(Some(p.id()), ctx!().tree, themes);
       let child = child.gen_widget(&ctx);

--- a/core/src/builtin_widgets/theme/compose_decorators.rs
+++ b/core/src/builtin_widgets/theme/compose_decorators.rs
@@ -50,7 +50,7 @@ where
     if let Some(style) = style {
       style(Box::new(self), host, ctx)
     } else {
-      ComposeDecorator::compose_decorator(self, host).widget_build(ctx)
+      ComposeDecorator::compose_decorator(self, host).build(ctx)
     }
   }
 }
@@ -103,7 +103,7 @@ mod tests {
             @ { host }
           }
         }
-        .widget_build(ctx)
+        .build(ctx)
       });
 
     let w = fn_widget! {

--- a/core/src/context/build_ctx.rs
+++ b/core/src/context/build_ctx.rs
@@ -194,7 +194,7 @@ mod tests {
                       size: ZERO_SIZE,
                       @ {
                         *$c_themes.write() = ctx!().themes().clone();
-                        Void.widget_build(ctx!())
+                        Void.build(ctx!())
                       }
                     }
                   })

--- a/core/src/events/focus_mgr.rs
+++ b/core/src/events/focus_mgr.rs
@@ -836,9 +836,9 @@ mod tests {
               auto_focus: true,
               on_chars: move |e| $input_writer.write().push_str(&e.chars),
               size: Size::new(10., 10.),
-            }.widget_build(ctx!())
+            }.build(ctx!())
           } else {
-            Void.widget_build(ctx!())
+            Void.build(ctx!())
           }
         }}
       }
@@ -876,7 +876,7 @@ mod tests {
                   on_chars: move |e| if idx == 2 { $input_writer.write().push_str(&e.chars) },
                   size: Size::new(10., 10.),
                 }
-              }.widget_build(ctx!()))
+              }.build(ctx!()))
             }).collect::<Vec<_>>()
           }
         }

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -256,7 +256,7 @@ impl OverlayState {
       };
       let build_ctx = BuildCtx::new(None, &wnd.widget_tree);
       let style = style.unwrap_or_else(|| OverlayStyle::of(&build_ctx));
-      let w = this.wrap_style(w, style).widget_build(&build_ctx);
+      let w = this.wrap_style(w, style).build(&build_ctx);
       let wid = w.id();
       *this.0.borrow_mut() = OverlayInnerState::Showing(wid, wnd.clone());
       let root = wnd.widget_tree.borrow().root();

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -372,14 +372,12 @@ where
 
 impl<C: Compose + 'static> ComposeBuilder for State<C> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { Compose::compose(self).widget_build(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { Compose::compose(self).build(ctx) }
 }
 
 impl<P: ComposeChild<Child = Option<C>> + 'static, C> ComposeChildBuilder for State<P> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
-    ComposeChild::compose_child(self, None).widget_build(ctx)
-  }
+  fn build(self, ctx: &BuildCtx) -> Widget { ComposeChild::compose_child(self, None).build(ctx) }
 }
 
 impl<W: SingleChild> SingleChild for State<W> {}
@@ -387,10 +385,10 @@ impl<W: MultiChild> MultiChild for State<W> {}
 
 impl<R: Render> RenderBuilder for State<R> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     match self.0.into_inner() {
-      InnerState::Data(w) => w.into_inner().widget_build(ctx),
-      InnerState::Stateful(w) => w.widget_build(ctx),
+      InnerState::Data(w) => w.into_inner().build(ctx),
+      InnerState::Stateful(w) => w.build(ctx),
     }
   }
 }
@@ -449,9 +447,7 @@ macro_rules! impl_compose_builder {
       WM: Fn(&mut W::Value) -> &mut V + Clone + 'static,
       V: Compose + 'static,
     {
-      fn widget_build(self, ctx: &crate::context::BuildCtx) -> Widget {
-        Compose::compose(self).widget_build(ctx)
-      }
+      fn build(self, ctx: &crate::context::BuildCtx) -> Widget { Compose::compose(self).build(ctx) }
     }
 
     impl<V, W, RM, WM, Child> ComposeChildBuilder for $name<W, RM, WM>
@@ -462,8 +458,8 @@ macro_rules! impl_compose_builder {
       V: ComposeChild<Child = Option<Child>> + 'static,
     {
       #[inline]
-      fn widget_build(self, ctx: &BuildCtx) -> Widget {
-        ComposeChild::compose_child(self, None).widget_build(ctx)
+      fn build(self, ctx: &BuildCtx) -> Widget {
+        ComposeChild::compose_child(self, None).build(ctx)
       }
     }
   };

--- a/core/src/state/map_state.rs
+++ b/core/src/state/map_state.rs
@@ -133,7 +133,7 @@ where
   V: Render,
 {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { RenderProxy::new(self).widget_build(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { RenderProxy::new(self).build(ctx) }
 }
 
 impl<V, S, RM, WM> RenderBuilder for MapWriter<S, RM, WM>
@@ -145,7 +145,7 @@ where
   V: Render,
 {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { self.clone_reader().widget_build(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { self.clone_reader().build(ctx) }
 }
 
 impl<V, S, RM, WM> MapWriter<S, RM, WM>

--- a/core/src/state/splitted_state.rs
+++ b/core/src/state/splitted_state.rs
@@ -241,11 +241,11 @@ where
   W: Fn(&mut O::Value) -> &mut V + Clone,
   V: Render,
 {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     MapReader {
       origin: self.origin.clone_reader(),
       map: self.map.clone(),
     }
-    .widget_build(ctx)
+    .build(ctx)
   }
 }

--- a/core/src/state/stateful.rs
+++ b/core/src/state/stateful.rs
@@ -229,13 +229,13 @@ macro_rules! compose_builder_impl {
   ($name: ident) => {
     impl<C: Compose + 'static> ComposeBuilder for $name<C> {
       #[inline]
-      fn widget_build(self, ctx: &BuildCtx) -> Widget { Compose::compose(self).widget_build(ctx) }
+      fn build(self, ctx: &BuildCtx) -> Widget { Compose::compose(self).build(ctx) }
     }
 
     impl<R: ComposeChild<Child = Option<C>> + 'static, C> ComposeChildBuilder for $name<R> {
       #[inline]
-      fn widget_build(self, ctx: &BuildCtx) -> Widget {
-        ComposeChild::compose_child(self, None).widget_build(ctx)
+      fn build(self, ctx: &BuildCtx) -> Widget {
+        ComposeChild::compose_child(self, None).build(ctx)
       }
     }
   };
@@ -245,11 +245,11 @@ compose_builder_impl!(Stateful);
 compose_builder_impl!(Writer);
 
 impl<R: Render> RenderBuilder for Stateful<R> {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     match self.try_into_value() {
-      Ok(r) => r.widget_build(ctx),
+      Ok(r) => r.build(ctx),
       Err(s) => {
-        let w = RenderProxy::new(s.data.clone()).widget_build(ctx);
+        let w = RenderProxy::new(s.data.clone()).build(ctx);
         w.dirty_subscribe(s.raw_modifies(), ctx)
       }
     }
@@ -258,12 +258,12 @@ impl<R: Render> RenderBuilder for Stateful<R> {
 
 impl<R: Render> RenderBuilder for Writer<R> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { self.0.widget_build(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { self.0.build(ctx) }
 }
 
 impl<R: Render> RenderBuilder for Reader<R> {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { self.0.clone_writer().widget_build(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { self.0.clone_writer().build(ctx) }
 }
 
 impl<W> Stateful<W> {
@@ -313,7 +313,7 @@ impl<W: MultiChild> MultiChild for Stateful<W> {}
 
 impl<W: SingleChild + Render> SingleParent for Stateful<W> {
   fn compose_child(self, child: Widget, ctx: &BuildCtx) -> Widget {
-    let p = self.widget_build(ctx);
+    let p = self.build(ctx);
     ctx.append_child(p.id(), child);
     p
   }
@@ -321,7 +321,7 @@ impl<W: SingleChild + Render> SingleParent for Stateful<W> {
 
 impl<W: MultiChild + Render> MultiParent for Stateful<W> {
   fn compose_children(self, children: impl Iterator<Item = Widget>, ctx: &BuildCtx) -> Widget {
-    let p = self.widget_build(ctx);
+    let p = self.build(ctx);
     for c in children {
       ctx.append_child(p.id(), c);
     }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -147,10 +147,10 @@ impl<'a> dyn Render + 'a {
 /// A indirect widget is a widget that is not `Compose`, `Render` and
 /// `ComposeChild`,  like function widget and  `Pipe<Widget>`.
 pub trait WidgetBuilder {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget;
+  fn build(self, ctx: &BuildCtx) -> Widget;
 
   /// Convert the widget to named type widget `FnWidget`, this is useful when
-  /// you want store a widget and not want to call `widget_build(ctx!())` to
+  /// you want store a widget and not want to call `build(ctx!())` to
   /// build it into the widget tree.
   ///
   /// # Example
@@ -166,7 +166,7 @@ pub trait WidgetBuilder {
   where
     Self: Sized + 'static,
   {
-    Box::new(move |ctx| self.widget_build(ctx))
+    Box::new(move |ctx| self.build(ctx))
   }
 }
 
@@ -174,14 +174,14 @@ pub trait WidgetBuilder {
 /// build phase. You should not implement this trait directly, implement
 /// `Compose` trait instead.
 pub trait ComposeBuilder {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget;
+  fn build(self, ctx: &BuildCtx) -> Widget;
 }
 
 /// Trait to build a render widget into widget tree with `BuildCtx` in the build
 /// phase. You should not implement this trait directly, implement `Render`
 /// trait instead.
 pub trait RenderBuilder {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget;
+  fn build(self, ctx: &BuildCtx) -> Widget;
 }
 
 /// Trait to build a `ComposeChild` widget without child into widget tree with
@@ -189,12 +189,12 @@ pub trait RenderBuilder {
 /// `Option<>_`  . You should not implement this trait directly,
 /// implement `ComposeChild` trait instead.
 pub trait ComposeChildBuilder {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget;
+  fn build(self, ctx: &BuildCtx) -> Widget;
 }
 
 /// Trait only for `Widget`, you should not implement this trait.
 pub trait SelfBuilder {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget;
+  fn build(self, ctx: &BuildCtx) -> Widget;
 }
 
 impl Widget {
@@ -236,7 +236,7 @@ impl Widget {
 
 impl SelfBuilder for Widget {
   #[inline(always)]
-  fn widget_build(self, _: &BuildCtx) -> Widget { self }
+  fn build(self, _: &BuildCtx) -> Widget { self }
 }
 
 impl<F> WidgetBuilder for F
@@ -244,12 +244,12 @@ where
   F: FnOnce(&BuildCtx) -> Widget,
 {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { self(ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { self(ctx) }
 }
 
 impl WidgetBuilder for GenWidget {
   #[inline]
-  fn widget_build(mut self, ctx: &BuildCtx) -> Widget { self.gen_widget(ctx) }
+  fn build(mut self, ctx: &BuildCtx) -> Widget { self.gen_widget(ctx) }
 }
 
 impl GenWidget {
@@ -383,20 +383,18 @@ macro_rules! impl_proxy_render {
 
 impl<C: Compose + 'static> ComposeBuilder for C {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
-    Compose::compose(State::value(self)).widget_build(ctx)
-  }
+  fn build(self, ctx: &BuildCtx) -> Widget { Compose::compose(State::value(self)).build(ctx) }
 }
 
 impl<R: Render + 'static> RenderBuilder for R {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget { Widget::new(Box::new(self), ctx) }
+  fn build(self, ctx: &BuildCtx) -> Widget { Widget::new(Box::new(self), ctx) }
 }
 
 impl<W: ComposeChild<Child = Option<C>> + 'static, C> ComposeChildBuilder for W {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
-    ComposeChild::compose_child(State::value(self), None).widget_build(ctx)
+  fn build(self, ctx: &BuildCtx) -> Widget {
+    ComposeChild::compose_child(State::value(self), None).build(ctx)
   }
 }
 

--- a/core/src/widget_children.rs
+++ b/core/src/widget_children.rs
@@ -48,7 +48,7 @@ pub type WidgetOf<W> = Pair<W, Widget>;
 
 impl RenderBuilder for BoxedSingleChild {
   #[inline]
-  fn widget_build(self, _: &BuildCtx) -> Widget { self.0 }
+  fn build(self, _: &BuildCtx) -> Widget { self.0 }
 }
 
 impl SingleParent for BoxedSingleChild {
@@ -61,7 +61,7 @@ impl SingleParent for BoxedSingleChild {
 
 impl RenderBuilder for BoxedMultiChild {
   #[inline]
-  fn widget_build(self, _: &BuildCtx) -> Widget { self.0 }
+  fn build(self, _: &BuildCtx) -> Widget { self.0 }
 }
 
 impl MultiParent for BoxedMultiChild {
@@ -89,7 +89,7 @@ pub(crate) trait MultiParent {
 
 impl<T: Render + SingleChild> SingleParent for T {
   fn compose_child(self, child: Widget, ctx: &BuildCtx) -> Widget {
-    let p = self.widget_build(ctx);
+    let p = self.build(ctx);
     ctx.append_child(p.id(), child);
 
     p
@@ -108,7 +108,7 @@ impl<T: SingleParent> SingleParent for Option<T> {
 
 impl<T: Render + MultiChild> MultiParent for T {
   fn compose_children(self, children: impl Iterator<Item = Widget>, ctx: &BuildCtx) -> Widget {
-    let p = self.widget_build(ctx);
+    let p = self.build(ctx);
     for c in children {
       ctx.append_child(p.id(), c);
     }
@@ -119,7 +119,7 @@ impl<T: Render + MultiChild> MultiParent for T {
 impl BoxedSingleChild {
   #[inline]
   pub fn new(widget: impl RenderBuilder + SingleChild, ctx: &BuildCtx) -> Self {
-    Self(widget.widget_build(ctx))
+    Self(widget.build(ctx))
   }
 
   /// Create a `BoxedSingleChild` from a `Widget` and not check the type , the
@@ -131,7 +131,7 @@ impl BoxedSingleChild {
 impl BoxedMultiChild {
   #[inline]
   pub fn new(widget: impl RenderBuilder + MultiChild, ctx: &BuildCtx) -> Self {
-    Self(widget.widget_build(ctx))
+    Self(widget.build(ctx))
   }
 }
 
@@ -378,7 +378,7 @@ mod tests {
 
     let _ = |ctx| -> Widget {
       let child = MockBox { size: ZERO_SIZE }.with_child(Void, ctx);
-      X.with_child(child, ctx).widget_build(ctx)
+      X.with_child(child, ctx).build(ctx)
     };
   }
 

--- a/core/src/widget_children/child_convert.rs
+++ b/core/src/widget_children/child_convert.rs
@@ -31,7 +31,7 @@ pub trait FromAnother<V, M> {
 crate::widget::multi_build_replace_impl! {
   impl<W: {#} > FromAnother<W, &dyn {#}> for Widget {
     #[inline]
-    fn from_another(value: W, ctx: &BuildCtx) -> Self { value.widget_build(ctx) }
+    fn from_another(value: W, ctx: &BuildCtx) -> Self { value.build(ctx) }
   }
 }
 

--- a/core/src/widget_children/compose_child_impl.rs
+++ b/core/src/widget_children/compose_child_impl.rs
@@ -108,9 +108,9 @@ where
   Child: From<C>,
 {
   #[inline]
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     let Self { parent, child } = self;
-    ComposeChild::compose_child(parent, child.into()).widget_build(ctx)
+    ComposeChild::compose_child(parent, child.into()).build(ctx)
   }
 }
 
@@ -202,14 +202,14 @@ mod tests {
   }
 
   #[test]
-  fn template_fill_template() { let _ = |ctx| P.with_child(Void, ctx).widget_build(ctx); }
+  fn template_fill_template() { let _ = |ctx| P.with_child(Void, ctx).build(ctx); }
 
   #[test]
   fn pair_compose_child() {
     let _ = |ctx| -> Widget {
       MockBox { size: ZERO_SIZE }
         .with_child(X.with_child(Void {}, ctx), ctx)
-        .widget_build(ctx)
+        .build(ctx)
     };
   }
 

--- a/core/src/widget_children/multi_child_impl.rs
+++ b/core/src/widget_children/multi_child_impl.rs
@@ -20,7 +20,7 @@ trait FillVec<M: ?Sized> {
 crate::widget::multi_build_replace_impl_include_self! {
   impl<W: {#}> FillVec<dyn {#}> for W {
     #[inline]
-    fn fill_vec(self, vec: &mut Vec<Widget>, ctx: &BuildCtx) { vec.push(self.widget_build(ctx)) }
+    fn fill_vec(self, vec: &mut Vec<Widget>, ctx: &BuildCtx) { vec.push(self.build(ctx)) }
   }
 
   impl<W> FillVec<&dyn {#}> for W
@@ -30,7 +30,7 @@ crate::widget::multi_build_replace_impl_include_self! {
   {
     #[inline]
     fn fill_vec(self, vec: &mut Vec<Widget>, ctx: &BuildCtx) {
-      vec.extend(self.into_iter().map(|w| w.widget_build(ctx)))
+      vec.extend(self.into_iter().map(|w| w.build(ctx)))
     }
   }
 }
@@ -43,7 +43,7 @@ crate::widget::multi_build_replace_impl_include_self! {
     V::Item: {#},
   {
     fn fill_vec(self, vec: &mut Vec<Widget>, ctx: &BuildCtx) {
-      self.build_multi(vec, |v, ctx| v.widget_build(ctx), ctx);
+      self.build_multi(vec, |v, ctx| v.build(ctx), ctx);
     }
   }
 }
@@ -75,7 +75,7 @@ where
 }
 
 impl<P: MultiParent> WidgetBuilder for MultiPair<P> {
-  fn widget_build(self, ctx: &BuildCtx) -> Widget {
+  fn build(self, ctx: &BuildCtx) -> Widget {
     let MultiPair { parent, children } = self;
     parent.compose_children(children.into_iter(), ctx)
   }

--- a/core/src/widget_children/single_child_impl.rs
+++ b/core/src/widget_children/single_child_impl.rs
@@ -14,7 +14,7 @@ crate::widget::multi_build_replace_impl_include_self! {
     type Target = Widget;
 
     fn with_child(self, child: C, ctx: &BuildCtx) -> Self::Target {
-      self.compose_child(child.widget_build(ctx), ctx)
+      self.compose_child(child.build(ctx), ctx)
     }
   }
 
@@ -29,7 +29,7 @@ crate::widget::multi_build_replace_impl_include_self! {
       if let Some(child) = child {
         self.with_child(child, ctx)
       } else {
-        self.widget_build(ctx)
+        self.build(ctx)
       }
     }
   }
@@ -64,7 +64,7 @@ mod tests {
       mock_box
         .clone()
         .with_child(mock_box.clone().with_child(mock_box, ctx), ctx)
-        .widget_build(ctx)
+        .build(ctx)
     };
   }
 

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -256,9 +256,9 @@ mod tests {
               .map(move |(width, depth)| {
                 (0..width).map(move |_| -> Widget {
                   if depth > 1 {
-                    Recursive { width, depth: depth - 1 }.widget_build(ctx!())
+                    Recursive { width, depth: depth - 1 }.build(ctx!())
                   } else {
-                    MockBox { size: Size::new(10., 10.)}.widget_build(ctx!())
+                    MockBox { size: Size::new(10., 10.)}.build(ctx!())
                   }
                 })
               })
@@ -280,9 +280,9 @@ mod tests {
         let recursive_child: Widget = if $this.depth > 1 {
           let width = $this.width;
           let depth = $this.depth - 1;
-          Embed { width, depth }.widget_build(ctx!())
+          Embed { width, depth }.build(ctx!())
         } else {
-          MockBox { size: Size::new(10., 10.) }.widget_build(ctx!())
+          MockBox { size: Size::new(10., 10.) }.build(ctx!())
         };
         let multi = pipe!{
           (0..$this.width - 1).map(|_| MockBox { size: Size::new(10., 10.)})
@@ -358,9 +358,9 @@ mod tests {
             @MockBox {
               size: Size::zero(),
               @ { pipe!($child.then(|| Void)) }
-            }.widget_build(ctx!())
+            }.build(ctx!())
           } else {
-            Void.widget_build(ctx!())
+            Void.build(ctx!())
           }
         })
       }

--- a/core/src/widget_tree/layout_info.rs
+++ b/core/src/widget_tree/layout_info.rs
@@ -343,9 +343,9 @@ mod tests {
       @MockMulti {
         on_performed_layout: move |_| *$root_layout_cnt.write() += 1,
         @ { pipe!($child_box.size.is_empty()).map(move|b| if b {
-            MockBox { size: Size::new(1., 1.) }.widget_build(ctx!())
+            MockBox { size: Size::new(1., 1.) }.build(ctx!())
           } else {
-            child_box.clone_writer().into_inner().widget_build(ctx!())
+            child_box.clone_writer().into_inner().build(ctx!())
           })
         }
       }

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -286,7 +286,7 @@ impl Window {
 
   pub fn set_content_widget(&self, root: impl WidgetBuilder) {
     let build_ctx = BuildCtx::new(None, &self.widget_tree);
-    let root = root.widget_build(&build_ctx);
+    let root = root.build(&build_ctx);
     self.widget_tree.borrow_mut().set_content(root.consume())
   }
 

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -45,7 +45,7 @@ use ribir::prelude::*;
 
 fn hello_world(ctx!(): &BuildCtx) -> Widget {
   rdl!{ Text { text: "Hello World!" } }
-    .widget_build(ctx!())
+    .build(ctx!())
 }
 
 fn main() { 
@@ -57,7 +57,7 @@ At first, you should find the difference in the parameter declaration (`ctx!(): 
   
 Then, you can see the next line `rdl!{ Text { text: "Hello World!" } }`, which creates a `Text` with the content `Hello World!` through `rdl!`. The details of `rdl!` will be put aside for now, and will be introduced in detail in the section [Creating objects using `rdl!`](#creating-objects-using-rdl).
 
-Finally, build `Text` into `Widget` through the `widget_build` method as the return value of the function.
+Finally, build `Text` into `Widget` through the `build` method as the return value of the function.
 
 
 > Tip
@@ -74,7 +74,7 @@ use ribir::prelude::*;
 fn main() {
   let hello_world = |ctx!(): &BuildCtx| {
     rdl!{ Text { text: "Hello World!" } }
-      .widget_build(ctx!())
+      .build(ctx!())
   };
   App::run(hello_world);
 }
@@ -87,7 +87,7 @@ move |ctx!(): &BuildCtx| -> Widget {
   {
     // Your code
   }
-  .widget_build(ctx!())
+  .build(ctx!())
 }
 ```
 

--- a/docs/en/practice_todos_app/develop_a_todos_app.md
+++ b/docs/en/practice_todos_app/develop_a_todos_app.md
@@ -349,7 +349,7 @@ where
     @ListItem {
       @{ HeadlineText(Label::new($task.label.clone())) }
       @Leading {
-        @{ CustomEdgeWidget(checkbox.widget_build(ctx!())) }
+        @{ CustomEdgeWidget(checkbox.build(ctx!())) }
       }
       @Trailing {
         cursor: CursorIcon::Pointer,
@@ -441,12 +441,12 @@ fn_widget! {
                           }
                         }
                       }
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   } else {
                     let item = task_item(task.clone_writer());
                     @$item {
                       on_double_tap: move |_| *$editing.write() = Some(id)
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   }
                 });
               widgets.push(item);
@@ -647,12 +647,12 @@ fn task_lists(this: &impl StateWriter<Value = Todos>, cond: fn(&Task) -> bool) -
                           }
                         }
                       }
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   } else {
                     let item = task_item(task.clone_writer());
                     @$item {
                       on_double_tap: move |_| *$editing.write() = Some(id)
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   }
                 });
               widgets.push(item);
@@ -684,7 +684,7 @@ where
     @$item {
       @{ HeadlineText(Label::new($task.label.clone())) }
       @Leading {
-        @{ CustomEdgeWidget(checkbox.widget_build(ctx!())) }
+        @{ CustomEdgeWidget(checkbox.build(ctx!())) }
       }
       @Trailing {
         cursor: CursorIcon::Pointer,

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -45,7 +45,7 @@ use ribir::prelude::*;
 
 fn hello_world(ctx!(): &BuildCtx) -> Widget {
   rdl!{ Text { text: "Hello World!" } }
-    .widget_build(ctx!())
+    .build(ctx!())
 }
 
 fn main() { 
@@ -57,7 +57,7 @@ fn main() {
 
 接下来一行 `rdl!{ Text { text: "Hello World!" } }`，通过 `rdl！` 创建了一个内容为 `Hello World!` 的 `Text`。关于 `rdl!` 的细节，你可以先放到一边，将在小节 [使用 `rdl!` 创建对象](#使用-rdl-创建对象) 中详细介绍。
 
-最后，将 `Text` 通过 `widget_build` 方法构建成 `Widget`，作为函数的返回值。
+最后，将 `Text` 通过 `build` 方法构建成 `Widget`，作为函数的返回值。
 
 > 小提示
 >
@@ -73,7 +73,7 @@ use ribir::prelude::*;
 fn main() {
   let hello_world = |ctx!(): &BuildCtx| {
     rdl!{ Text { text: "Hello World!" } }
-      .widget_build(ctx!())
+      .build(ctx!())
   };
   App::run(hello_world);
 }
@@ -86,7 +86,7 @@ move |ctx!(): &BuildCtx| -> Widget {
   {
     // 你的代码
   }
-  .widget_build(ctx!())
+  .build(ctx!())
 }
 ```
 

--- a/docs/zh/practice_todos_app/develop_a_todos_app.md
+++ b/docs/zh/practice_todos_app/develop_a_todos_app.md
@@ -352,7 +352,7 @@ where
     @ListItem {
       @{ HeadlineText(Label::new($task.label.clone())) }
       @Leading {
-        @{ CustomEdgeWidget(checkbox.widget_build(ctx!())) }
+        @{ CustomEdgeWidget(checkbox.build(ctx!())) }
       }
       @Trailing {
         cursor: CursorIcon::Pointer,
@@ -444,12 +444,12 @@ fn_widget! {
                           }
                         }
                       }
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   } else {
                     let item = task_item(task.clone_writer());
                     @$item {
                       on_double_tap: move |_| *$editing.write() = Some(id)
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   }
                 });
               widgets.push(item);
@@ -650,12 +650,12 @@ fn task_lists(this: &impl StateWriter<Value = Todos>, cond: fn(&Task) -> bool) -
                           }
                         }
                       }
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   } else {
                     let item = task_item(task.clone_writer());
                     @$item {
                       on_double_tap: move |_| *$editing.write() = Some(id)
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   }
                 });
               widgets.push(item);
@@ -686,7 +686,7 @@ where
     @$item {
       @{ HeadlineText(Label::new($task.label.clone())) }
       @Leading {
-        @{ CustomEdgeWidget(checkbox.widget_build(ctx!())) }
+        @{ CustomEdgeWidget(checkbox.build(ctx!())) }
       }
       @Trailing {
         cursor: CursorIcon::Pointer,

--- a/examples/todos/src/ui.rs
+++ b/examples/todos/src/ui.rs
@@ -73,14 +73,14 @@ fn task_lists(this: &impl StateWriter<Value = Todos>, cond: fn(&Task) -> bool) -
                           }
                         }
                       }
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
 
                   } else {
                     let _hint = || $stagger.write();
                     let item = task_item_widget(task.clone_writer(), stagger.clone_writer());
                     @$item {
                       on_double_tap: move |_| *$editing.write() = Some(id)
-                    }.widget_build(ctx!())
+                    }.build(ctx!())
                   }
                 });
 
@@ -153,7 +153,7 @@ where
           watch!($checkbox.checked)
             .distinct_until_changed()
             .subscribe(move |v| $task.write().complete = v);
-          CustomEdgeWidget(checkbox.widget_build(ctx!()))
+          CustomEdgeWidget(checkbox.build(ctx!()))
         }
       }
       @Trailing {

--- a/macros/src/fn_widget_macro.rs
+++ b/macros/src/fn_widget_macro.rs
@@ -16,7 +16,7 @@ impl FnWidgetMacro {
     let stmts: Vec<_> = body.0.into_iter().map(|s| refs_ctx.fold_stmt(s)).collect();
     let _ = refs_ctx.pop_dollar_scope(true);
     quote! {
-      move |ctx!(): &BuildCtx| -> Widget { #(#stmts)*.widget_build(ctx!()) }
+      move |ctx!(): &BuildCtx| -> Widget { #(#stmts)*.build(ctx!()) }
     }
     .into()
   }

--- a/themes/material/src/lib.rs
+++ b/themes/material/src/lib.rs
@@ -274,7 +274,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
 
       thumb
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<VScrollBarThumbDecorator>(|this, host, ctx| {
     fn_widget! {
@@ -286,7 +286,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
 
       thumb
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<IndicatorDecorator>(|style, host, ctx| {
     fn_widget! {
@@ -323,7 +323,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
 
       indicator
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<CheckBoxDecorator>(move |style, host, ctx| {
     fn_widget! {
@@ -341,7 +341,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
         }
       }
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<FilledButtonDecorator>(move |style, host, ctx| {
     fn_widget! {
@@ -364,7 +364,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
         }
       }
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<OutlinedButtonDecorator>(move |style, host, ctx| {
     fn_widget! {
@@ -387,7 +387,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
         }
       }
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   styles.override_compose_decorator::<ButtonDecorator>(move |style, host, ctx| {
     fn_widget! {
@@ -410,7 +410,7 @@ fn override_compose_decorator(theme: &mut FullTheme) {
         }
       }
     }
-    .widget_build(ctx)
+    .build(ctx)
   });
   let textfield = TextFieldThemeSuit::from_theme(&theme.palette, &theme.typography_theme);
   theme.custom_styles.set_custom_style(textfield);

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -76,7 +76,7 @@ impl ComposeChild for Checkbox {
             }
           }}
         }
-      }.widget_build(ctx!());
+      }.build(ctx!());
 
       let checkbox = if let Some(child) = child  {
         let label = |label: State<Label>| @Text {
@@ -89,14 +89,14 @@ impl ComposeChild for Checkbox {
           @ {
             match child {
               CheckboxTemplate::Before(w) => {
-                [w.child_replace_host().map(label).widget_build(ctx!()), icon]
+                [w.child_replace_host().map(label).build(ctx!()), icon]
               },
               CheckboxTemplate::After(w) => {
-                [icon, w.child_replace_host().map(label).widget_build(ctx!())]
+                [icon, w.child_replace_host().map(label).build(ctx!())]
               },
             }
           }
-        }.widget_build(ctx!())
+        }.build(ctx!())
       } else {
         icon
       };

--- a/widgets/src/input.rs
+++ b/widgets/src/input.rs
@@ -409,7 +409,7 @@ where
         }
       };
 
-      let text_widget = text.widget_build(ctx!());
+      let text_widget = text.build(ctx!());
       let text_widget = bind_point_listener(
         this.clone_writer(),
         text_widget,

--- a/widgets/src/input/text_selectable.rs
+++ b/widgets/src/input/text_selectable.rs
@@ -164,7 +164,7 @@ impl ComposeChild for TextSelectable {
           }
         }
       };
-      let text_widget = text.widget_build(ctx!());
+      let text_widget = text.build(ctx!());
       let text_widget = bind_point_listener(
         this.clone_writer(),
         text_widget,

--- a/widgets/src/lists.rs
+++ b/widgets/src/lists.rs
@@ -63,7 +63,7 @@ use ribir_core::prelude::*;
 ///           @Container {
 ///             size: Size::splat(40.),
 ///             background: Color::YELLOW,
-///           }.widget_build(ctx!())
+///           }.build(ctx!())
 ///         )
 ///       }
 ///     }
@@ -96,7 +96,7 @@ use ribir_core::prelude::*;
 ///           @Container {
 ///             size: Size::splat(40.),
 ///             background: Color::YELLOW,
-///           }.widget_build(ctx!())
+///           }.build(ctx!())
 ///         )
 ///       }
 ///     }


### PR DESCRIPTION
## Purpose of this Pull Request

Renamed the `widget_build` method to `build` for brevity, given its frequent usage

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.