### PR TITLE
fix(core): 🐛 rename builtin field of  delay_drop_until to keep_alive,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## [@Unreleased] - @ReleaseDate
 
+- **core**: rename builtin field of delay_drop_until to keep_alive (#561 @wjian23)
+
 ## [0.3.0-alpha.4] - 2024-04-17
 
 ## [0.3.0-alpha.3] - 2024-04-10

--- a/core/src/builtin_widgets/keep_alive.rs
+++ b/core/src/builtin_widgets/keep_alive.rs
@@ -1,29 +1,29 @@
 use crate::prelude::*;
 
-/// A widget that can delay drop its child until the `delay_drop_until` field be
-/// set to `true`.
+/// A widget will be painted event if it has been dispose until the `keep_alive`
+/// field be set to `false` or its parent is dropped.
 ///
 /// This widget not effect the widget lifecycle, if the widget is dispose but
-/// the `delay_drop_until` is `false`, it's not part of the widget tree anymore
+/// the `keep_alive` is `true`, it's not part of the widget tree anymore
 /// but not drop immediately, is disposed in `logic`, but not release resource.
 /// It's be isolated from the widget tree and can layout and paint normally.
 ///
-/// Once the `delay_drop_until` field be set to `true`, the widget will be
+/// Once the `keep_alive` field be set to `false`, the widget will be
 /// dropped.
 ///
 /// It's useful when you need run a leave animation for a widget.
 #[derive(Query, Default)]
-pub struct DelayDrop {
-  pub delay_drop_until: bool,
+pub struct KeepAlive {
+  pub keep_alive: bool,
 }
 
-impl Declare for DelayDrop {
+impl Declare for KeepAlive {
   type Builder = FatObj<()>;
   #[inline]
   fn declarer() -> Self::Builder { FatObj::new(()) }
 }
 
-impl ComposeChild for DelayDrop {
+impl ComposeChild for KeepAlive {
   type Child = Widget;
   #[inline]
   fn compose_child(this: impl StateWriter<Value = Self>, child: Self::Child) -> impl WidgetBuilder {
@@ -45,8 +45,8 @@ mod tests {
   fn smoke() {
     reset_test_env!();
 
-    let delay_drop = Stateful::new(false);
-    let c_delay_drop = delay_drop.clone_writer();
+    let keep_alive = Stateful::new(true);
+    let c_keep_alive = keep_alive.clone_writer();
     let remove_widget = Stateful::new(false);
     let c_remove_widget = remove_widget.clone_writer();
     let mut wnd = TestWindow::new(fn_widget! {
@@ -55,7 +55,7 @@ mod tests {
           Void.build(ctx!())
         } else {
           FatObj::new(Void)
-            .delay_drop_until(pipe!(*$delay_drop))
+            .keep_alive(pipe!(*$keep_alive))
             .build(ctx!())
         }
       }
@@ -73,7 +73,7 @@ mod tests {
     wnd.draw_frame();
     assert!(!root.is_dropped(&tree_arena(&wnd)));
 
-    *c_delay_drop.write() = true;
+    *c_keep_alive.write() = false;
     wnd.draw_frame();
     assert!(root.is_dropped(&tree_arena(&wnd)));
   }

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -1394,7 +1394,7 @@ mod tests {
     fn build(task: Writer<Task>) -> impl WidgetBuilder {
       fn_widget! {
        @TaskWidget {
-          delay_drop_until: pipe!(!$task.pin),
+          keep_alive: pipe!($task.pin),
           layout_cnt: pipe!($task.layout_cnt.clone()),
           paint_cnt: pipe!($task.paint_cnt.clone()),
           trigger: pipe!($task.trigger),
@@ -1519,10 +1519,10 @@ mod tests {
       @MockMulti {
         @ { pipe!(*$child).map(move |_| {
           @MockMulti {
-            delay_drop_until: pipe!(*$child_destroy_until),
+            keep_alive: pipe!(!*$child_destroy_until),
             @ { pipe!(*$grandson).map(move |_| {
               @MockBox {
-                delay_drop_until: pipe!(*$grandson_destroy_until),
+                keep_alive: pipe!(!*$grandson_destroy_until),
                 size: Size::zero(),
               }
             })}

--- a/macros/src/declare_derive.rs
+++ b/macros/src/declare_derive.rs
@@ -552,12 +552,12 @@ pub(crate) fn declare_derive(input: &mut syn::DeriveInput) -> syn::Result<TokenS
           self
         }
 
-        #[doc="Initializes the `delay_drop_until` value of the `DelayDrop` widget."]
-        #vis fn delay_drop_until<_M, _V>(mut self, v: _V) -> Self
+        #[doc="Initializes the `keep_alive` value of the `KeepAlive` widget."]
+        #vis fn keep_alive<_M, _V>(mut self, v: _V) -> Self
         where
           DeclareInit<bool>: DeclareFrom<_V, _M>,
         {
-          self.fat_obj = self.fat_obj.delay_drop_until(v);
+          self.fat_obj = self.fat_obj.keep_alive(v);
           self
         }
 

--- a/macros/src/variable_names.rs
+++ b/macros/src/variable_names.rs
@@ -124,6 +124,6 @@ pub static BUILTIN_INFOS: phf::Map<&'static str, BuiltinMember> = phf_map! {
   "visible" => BuiltinMember { host_ty: "Visibility", mem_ty: Field, var_name: "visibility" },
   // Opacity
   "opacity" => BuiltinMember { host_ty: "Opacity", mem_ty: Field, var_name: "opacity" },
-  // DelayDrop
-  "delay_drop_until" => BuiltinMember { host_ty: "DelayDrop", mem_ty: Field, var_name: "delay_drop" },
+  // KeepAlive
+  "keep_alive" => BuiltinMember { host_ty: "KeepAlive", mem_ty: Field, var_name: "keep_alive" },
 };

--- a/themes/material/src/ripple.rs
+++ b/themes/material/src/ripple.rs
@@ -95,7 +95,7 @@ impl ComposeChild for Ripple {
           });
 
           Some(@IgnorePointer {
-            delay_drop_until: pipe!(!$ripper_fade_out.is_running()),
+            keep_alive: pipe!($ripper_fade_out.is_running()),
             on_disposed: move |_| $ripple.write().opacity = 0.,
             on_mounted: move |_| { ripper_enter.run(); },
             @Container {


### PR DESCRIPTION
## Purpose of this Pull Request

rename builtin field of delay_drop_until to keep_alive

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.