### PR TITLE
chore(ribir): 🤖 remove dep `raw-window-handle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = ["gui", "ui", "declarative", "compose-ui"]
 license = "MIT"
 readme = "README.md"
 version = "0.3.0-alpha.5"
-package = "1.77.0"
+rust-version = "1.77.0"
 
 [workspace.dependencies]
 ahash = "0.8.11"
@@ -65,7 +65,6 @@ paste = "1.0"
 pin-project-lite = "0.2.9"
 proc-macro2 = "1.0.81"
 quote = "1.0.16"
-raw-window-handle = "0.5"
 rayon = "1.5.1"
 rctree = "0.5.0"
 rustybuzz = "0.11.0"

--- a/ribir/Cargo.toml
+++ b/ribir/Cargo.toml
@@ -63,7 +63,6 @@ path = "tests/timer_test.rs"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
-raw-window-handle.workspace = true
 
 [package.metadata.release]
 tag = true


### PR DESCRIPTION
Updated several image test cases due to changes made on the CI machine.

## Purpose of this Pull Request

remove raw-window-handle

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.