### PR TITLE
build(ribir): 🤖 forked repo not call website to sync docs

### DIFF
--- a/.github/workflows/dispatch-other-repo.yml
+++ b/.github/workflows/dispatch-other-repo.yml
@@ -1,4 +1,4 @@
-name: "Dispatch other repo"
+name: "Call Website To Sync Docs"
 
 on:
   workflow_dispatch:
@@ -8,6 +8,8 @@ on:
       - release-*
 jobs:
   dispatch:
+    # Prevent this job from running on forked repositories
+    if: github.repository == 'RibirX/Ribir'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/github-script@v7


### PR DESCRIPTION
## Purpose of this Pull Request

Forked repo not call website to sync docs

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.