### PR TITLE
fix(core): 🐛 Release version compile failed due to the `borrowed_at` …

### DIFF
--- a/core/src/state/state_cell.rs
+++ b/core/src/state/state_cell.rs
@@ -49,7 +49,10 @@ impl<W> StateCell<W> {
     if !is_reading(b) {
       // If a borrow occurred, then we must already have an outstanding borrow,
       // so `borrowed_at` will be `Some`
-      panic!("already mutably borrowed: {:?}", self.borrowed_at.get().unwrap())
+      #[cfg(debug_assertions)]
+      panic!("Already mutably borrowed: {:?}", self.borrowed_at.get().unwrap());
+      #[cfg(not(debug_assertions))]
+      panic!("Already mutably borrowed");
     }
 
     // SAFETY: `BorrowRef` ensures that there is only immutable access
@@ -65,7 +68,10 @@ impl<W> StateCell<W> {
     // we explicitly only allow going from UNUSED to UNUSED - 1.
     let borrow = &self.borrow_flag;
     if borrow.get() != UNUSED {
-      panic!("already borrowed: {:?}", self.borrowed_at.get().unwrap())
+      #[cfg(debug_assertions)]
+      panic!("Already borrowed at: {:?}", self.borrowed_at.get().unwrap());
+      #[cfg(not(debug_assertions))]
+      panic!("Already borrowed");
     }
     #[cfg(debug_assertions)]
     {


### PR DESCRIPTION
…only available in debug

## Purpose of this Pull Request

Release version compilation failed due to the `borrowed_at` s only available in debug mode.

Introduced by #568 

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.