### PR TITLE
fix(ribir): 🐛 crash when creating a zero-sized window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 - **example**: run example in web wasm (#571 @wjian23)
 
+
+### Fixed
+
+- **ribir**: fixed the crash issue when the shell window is zero-sized at startup. (#582, @M-Adoo)
+
+
 ### Documented
 
 - **core**: Explained when to use `unsubscribe` with `watch!`. (#556, @M-Adoo)

--- a/ribir/src/backends/wgpu_backend.rs
+++ b/ribir/src/backends/wgpu_backend.rs
@@ -18,14 +18,17 @@ impl<'a> WinitBackend<'a> for WgpuBackend<'a> {
     let surface = instance.create_surface(window).unwrap();
     let wgpu = ribir_gpu::WgpuImpl::new(instance, Some(&surface)).await;
     let size = window.inner_size();
-    surface.configure(wgpu.device(), &Self::surface_config(size.width, size.height));
+    let size = DeviceSize::new(size.width as i32, size.height as i32);
 
-    WgpuBackend {
-      size: DeviceSize::new(size.width as i32, size.height as i32),
+    let mut wgpu = WgpuBackend {
+      size: DeviceSize::zero(),
       surface,
       backend: ribir_gpu::GPUBackend::new(wgpu, AntiAliasing::Msaa4X),
       current_texture: None,
-    }
+    };
+    wgpu.on_resize(size);
+
+    wgpu
   }
 
   fn on_resize(&mut self, size: DeviceSize) {


### PR DESCRIPTION
## Purpose of this Pull Request

Crashes may occur when creating a zero-sized window. This can also happen when creating a normal window, if the platform initially creates it with zero size and delays resizing.

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.