### PR TITLE
Feat/global build context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,14 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 <!-- next-header -->
 
-## [@Unreleased] - @ReleaseDat
+## [@Unreleased] - @ReleaseDate
 
 ### Features
 
 - **core**: Added the smooth widgets for transitioning the layout position and size. (#645 @M-Adoo)
 - **widgets**: Added three widgets `FractionallyWidthBox`, `FractionallyHeightBox`, and `FractionallySizedBox` to enable fractional sizing of widgets. (#647 @M-Adoo)
 - **widgets**: Add widget of radio button (#649 @wjian23)
-- **core**: `BuildCtx::get()` and `BuildCtx::get_mut()` have been added to facilitate access from anywhere within a build context. (#pr @M-Adoo)
+- **core**: `BuildCtx::get()` and `BuildCtx::get_mut()` have been added to facilitate access from anywhere within a build context. (#650 @M-Adoo)
 
 ### Fixed
 
@@ -40,7 +40,9 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### Breaking
 
 - **core**: `Expanded` and `KeyWidget` are not declared with `FatObj`, so they do not currently support built-in widgets. (#648 @M-Adoo)
-- **core**: `DeclareObj::finish` does not accept a `BuildCtx` parameter. (#pr @M-Adoo)
+- **core**: `DeclareObj::finish` does not accept a `BuildCtx` parameter. (#650 @M-Adoo)
+- **core**: function widget no longer requires a `&mut BuildCtx` parameter. (#650 @M-Adoo)
+- **macros**: Removed the `ctx!` macro. (#650 @M-Adoo)
 
 ## [0.4.0-alpha.14] - 2024-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### Breaking
 
 - **core**: `Expanded` and `KeyWidget` are not declared with `FatObj`, so they do not currently support built-in widgets. (#648 @M-Adoo)
+- **core**: `DeclareObj::finish` does not accept a `BuildCtx` parameter. (#pr @M-Adoo)
 
 ## [0.4.0-alpha.14] - 2024-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 - **core**: Added the smooth widgets for transitioning the layout position and size. (#645 @M-Adoo)
 - **widgets**: Added three widgets `FractionallyWidthBox`, `FractionallyHeightBox`, and `FractionallySizedBox` to enable fractional sizing of widgets. (#647 @M-Adoo)
 - **widgets**: Add widget of radio button (#649 @wjian23)
+- **core**: `BuildCtx::get()` and `BuildCtx::get_mut()` have been added to facilitate access from anywhere within a build context. (#pr @M-Adoo)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn main() {
 use ribir::prelude::*;
 
 fn main() {
-  let counter = |_: &mut BuildCtx| {
+  let counter = || {
     let cnt = Stateful::new(0);
 
     let c_cnt = cnt.clone_writer();

--- a/README.md
+++ b/README.md
@@ -70,21 +70,21 @@ fn main() {
 use ribir::prelude::*;
 
 fn main() {
-  let counter = |ctx: &mut BuildCtx| {
+  let counter = |_: &mut BuildCtx| {
     let cnt = Stateful::new(0);
 
     let c_cnt = cnt.clone_writer();
     let inc_btn = FilledButton::declarer()
       .on_tap(move |_| *c_cnt.write() += 1)
-      .finish(ctx)
+      .finish()
       .with_child(Label::new("Inc"));
 
     let counter = H1::declarer()
       .text(pipe!($cnt.to_string()))
-      .finish(ctx);
+      .finish();
 
     Row::declarer()
-      .finish(ctx)
+      .finish()
       .with_child(inc_btn)
       .with_child(counter)
       .into_widget()

--- a/core/src/animation/animate.rs
+++ b/core/src/animation/animate.rs
@@ -8,14 +8,14 @@ pub struct Animate<S>
 where
   S: AnimateState + 'static,
 {
-  #[declare(strict, default = transitions::LINEAR.of(ctx!()))]
+  #[declare(strict, default = transitions::LINEAR.of(BuildCtx::get()))]
   pub transition: Box<dyn Transition>,
   #[declare(strict)]
   pub state: S,
   pub from: S::Value,
   #[declare(skip)]
   running_info: Option<AnimateInfo<S::Value>>,
-  #[declare(skip, default = ctx!().window().id())]
+  #[declare(skip, default = BuildCtx::get().window().id())]
   window_id: WindowId,
 }
 

--- a/core/src/animation/animate_state.rs
+++ b/core/src/animation/animate_state.rs
@@ -21,9 +21,7 @@ pub trait AnimateState: AnimateStateSetter {
   fn calc_lerp_value(&mut self, from: &Self::Value, to: &Self::Value, rate: f32) -> Self::Value;
 
   /// Use an animate to transition the state after it modified.
-  fn transition(
-    self, transition: impl Transition + 'static, ctx: &BuildCtx,
-  ) -> Stateful<Animate<Self>>
+  fn transition(self, transition: impl Transition + 'static) -> Stateful<Animate<Self>>
   where
     Self: Sized,
     Self::Value: PartialEq,
@@ -33,7 +31,7 @@ pub trait AnimateState: AnimateStateSetter {
       .transition(Box::new(transition))
       .from(self.get())
       .state(self)
-      .finish(ctx);
+      .finish();
 
     let c_animate = animate.clone_writer();
     let init_value = observable::of(state.get());

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -149,7 +149,7 @@ impl LazyWidgetId {
   /// Bind a widget to the LazyWidgetId, and return a widget that will set the
   /// id to the LazyWidgetId after build.
   pub fn bind(self, widget: Widget) -> Widget {
-    widget.on_build(move |id, _| {
+    widget.on_build(move |id| {
       assert!(self.id().is_none(), "The LazyWidgetID only allows binding to one widget.");
       self.0.set(Some(id));
     })

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -903,7 +903,7 @@ impl<T> FatObj<T> {
 impl<T> ObjDeclarer for FatObj<T> {
   type Target = Self;
 
-  fn finish(self, _: &BuildCtx) -> Self::Target { self }
+  fn finish(self) -> Self::Target { self }
 }
 
 impl<'w, T, const M: usize> IntoWidgetStrict<'w, M> for FatObj<T>

--- a/core/src/builtin_widgets/box_decoration.rs
+++ b/core/src/builtin_widgets/box_decoration.rs
@@ -195,7 +195,7 @@ mod tests {
     let dummy = std::mem::MaybeUninit::uninit();
     // just for test, we know BoxDecoration not use `ctx` to build.
     let ctx: BuildCtx = unsafe { dummy.assume_init() };
-    let mut w = BoxDecoration::declarer().finish(&ctx);
+    let mut w = BoxDecoration::declarer().finish();
     let w = w.get_box_decoration_widget();
 
     assert_eq!(w.read().border, None);

--- a/core/src/builtin_widgets/global_anchor.rs
+++ b/core/src/builtin_widgets/global_anchor.rs
@@ -15,7 +15,7 @@ impl<'c> ComposeChild<'c> for GlobalAnchor {
   type Child = Widget<'c>;
   fn compose_child(this: impl StateWriter<Value = Self>, child: Self::Child) -> Widget<'c> {
     fn_widget! {
-      let wnd = ctx!().window();
+      let wnd = BuildCtx::get().window();
       let tick_of_layout_ready = wnd
         .frame_tick_stream()
         .filter(|msg| matches!(msg, FrameMsg::LayoutReady(_)));
@@ -87,11 +87,9 @@ impl<W> FatObj<W> {
   /// the left edge of the specified widget (`wid`) with the given relative
   /// pixel value (`relative`).
   // Todo: Should we control the subscription in the inner part?
-  pub fn left_align_to(
-    &mut self, wid: &LazyWidgetId, offset: f32, ctx: &BuildCtx,
-  ) -> impl Subscription {
+  pub fn left_align_to(&mut self, wid: &LazyWidgetId, offset: f32) -> impl Subscription {
     let this = self.get_global_anchor_widget().clone_writer();
-    let wnd = ctx.window();
+    let wnd = BuildCtx::get().window();
     let wid = wid.clone();
     let tick_of_layout_ready = wnd
       .frame_tick_stream()
@@ -107,11 +105,9 @@ impl<W> FatObj<W> {
   /// Anchor the widget's horizontal position by placing its right edge left to
   /// the right edge of the specified widget (`wid`) with the given relative
   /// pixel value (`relative`).
-  pub fn right_align_to(
-    &mut self, wid: &LazyWidgetId, relative: f32, ctx: &BuildCtx,
-  ) -> impl Subscription {
+  pub fn right_align_to(&mut self, wid: &LazyWidgetId, relative: f32) -> impl Subscription {
     let this = self.get_global_anchor_widget().clone_writer();
-    let wnd = ctx.window();
+    let wnd = BuildCtx::get().window();
     let wid = wid.clone();
     let tick_of_layout_ready = wnd
       .frame_tick_stream()
@@ -130,11 +126,9 @@ impl<W> FatObj<W> {
   /// Anchors the widget's vertical position by placing its top edge below the
   /// top edge of the specified widget (`wid`) with the given relative pixel
   /// value (`relative`).
-  pub fn top_align_to(
-    &mut self, wid: &LazyWidgetId, relative: f32, ctx: &BuildCtx,
-  ) -> impl Subscription {
+  pub fn top_align_to(&mut self, wid: &LazyWidgetId, relative: f32) -> impl Subscription {
     let this = self.get_global_anchor_widget().clone_writer();
-    let wnd = ctx.window();
+    let wnd = BuildCtx::get().window();
     let wid = wid.clone();
     let tick_of_layout_ready = wnd
       .frame_tick_stream()
@@ -150,11 +144,9 @@ impl<W> FatObj<W> {
   /// Anchors the widget's vertical position by placing its bottom edge above
   /// the bottom edge of the specified widget (`wid`) with the given relative
   /// pixel value (`relative`).
-  pub fn bottom_align_to(
-    &mut self, wid: &LazyWidgetId, relative: f32, ctx: &BuildCtx,
-  ) -> impl Subscription {
+  pub fn bottom_align_to(&mut self, wid: &LazyWidgetId, relative: f32) -> impl Subscription {
     let this = self.get_global_anchor_widget().clone_writer();
-    let wnd = ctx.window();
+    let wnd = BuildCtx::get().window();
     let wid = wid.clone();
     let tick_of_layout_ready = wnd
       .frame_tick_stream()
@@ -190,14 +182,14 @@ mod tests {
       let mut top_left = @MockBox {
         size: Size::new(10., 10.),
       };
-      top_left.left_align_to(&wid, 20., ctx!());
-      top_left.top_align_to(&wid, 10., ctx!());
+      top_left.left_align_to(&wid, 20.);
+      top_left.top_align_to(&wid, 10.);
 
       let mut bottom_right = @MockBox {
         size: Size::new(10., 10.),
       };
-      bottom_right.right_align_to(&wid, 10.,  ctx!());
-      bottom_right.bottom_align_to(&wid, 20., ctx!());
+      bottom_right.right_align_to(&wid, 10.);
+      bottom_right.bottom_align_to(&wid, 20.);
       @ $parent {
         @MockStack {
           @ { top_left }

--- a/core/src/builtin_widgets/keep_alive.rs
+++ b/core/src/builtin_widgets/keep_alive.rs
@@ -29,7 +29,7 @@ impl<'c> ComposeChild<'c> for KeepAlive {
     let modifies = this.raw_modifies();
     child
       .try_unwrap_state_and_attach(this)
-      .on_build(|id, ctx| id.dirty_subscribe(modifies, ctx))
+      .on_build(|id| id.dirty_subscribe(modifies, BuildCtx::get_mut().tree_mut()))
   }
 }
 

--- a/core/src/builtin_widgets/provider.rs
+++ b/core/src/builtin_widgets/provider.rs
@@ -119,7 +119,8 @@ impl<'c> ComposeChild<'c> for Provider {
       })
       .provider;
 
-    let f = move |ctx: &mut BuildCtx| {
+    let f = move |_: &mut BuildCtx| {
+      let ctx = BuildCtx::get_mut();
       let id = ctx.pre_alloc();
 
       // We need to push the `id` to providers; the build logic must create context

--- a/core/src/builtin_widgets/smooth_layout.rs
+++ b/core/src/builtin_widgets/smooth_layout.rs
@@ -19,13 +19,10 @@
 //!     // Create a smooth widget that operates on both the x-axis and y-axis.
 //!     let smooth = SmoothPos::default();
 //!     // Enable the transition
-//!     let _animate = smooth.transition(
-//!         EasingTransition {
-//!             easing: easing::LinearEasing,
-//!             duration: Duration::from_millis(1000),
-//!         },
-//!         ctx!(),
-//!     );
+//!     let _animate = smooth.transition(EasingTransition {
+//!        easing: easing::LinearEasing,
+//!        duration: Duration::from_millis(1000),
+//!     });
 //!
 //!     // Apply the smooth widget to the desired widget.
 //!     @ $smooth {
@@ -55,12 +52,12 @@ struct SmoothImpl<T> {
 
 impl<T: Copy + PartialEq + 'static> Stateful<SmoothImpl<T>> {
   fn transition(
-    &self, transition: impl Transition + 'static, ctx: &BuildCtx,
+    &self, transition: impl Transition + 'static,
   ) -> Stateful<Animate<impl AnimateState + 'static>>
   where
     T: Lerp,
   {
-    let animate = part_writer!(&mut self.value).transition(transition, ctx);
+    let animate = part_writer!(&mut self.value).transition(transition);
     let this = self.clone_writer();
     watch!($animate.is_running())
       .distinct_until_changed()
@@ -111,10 +108,10 @@ macro_rules! smooth_size_widget_impl {
 
     impl $name {
       #[doc = "Enable the transition with the provided argument and return the animation of the transition."]
-      pub fn transition(&self, transition: impl Transition + 'static, ctx: &BuildCtx)
+      pub fn transition(&self, transition: impl Transition + 'static)
         -> Stateful< Animate<impl AnimateState + 'static>>
       {
-        self.0.transition(transition, ctx)
+        self.0.transition(transition, )
       }
     }
   };
@@ -161,10 +158,10 @@ macro_rules! smooth_pos_widget_impl {
 
     impl $name {
       #[doc = "Enable the transition with the provided argument and return the animation of the transition."]
-      pub fn transition(&self, transition: impl Transition + 'static, ctx: &BuildCtx)
+      pub fn transition(&self, transition: impl Transition + 'static)
         -> Stateful< Animate<impl AnimateState + 'static>>
       {
-        self.0.transition(transition, ctx)
+        self.0.transition(transition)
       }
     }
   };

--- a/core/src/builtin_widgets/smooth_layout.rs
+++ b/core/src/builtin_widgets/smooth_layout.rs
@@ -101,7 +101,7 @@ macro_rules! smooth_size_widget_impl {
         fn_widget!{
           let modifies = this.read().0.raw_modifies();
           WrapRender::combine_child(this, child)
-            .on_build(move |id, ctx| id.dirty_subscribe(modifies, ctx))
+            .on_build(move |id, | id.dirty_subscribe(modifies, BuildCtx::get_mut().tree_mut()) )
         }.into_widget()
       }
     }

--- a/core/src/builtin_widgets/theme.rs
+++ b/core/src/builtin_widgets/theme.rs
@@ -285,15 +285,15 @@ mod tests {
       let mut theme = Theme::default();
       theme.palette.brightness = Brightness::Light;
       theme.with_child(fn_widget! {
-        $writer.write().push(Palette::of(ctx!()).brightness);
+        $writer.write().push(Palette::of(BuildCtx::get()).brightness);
         let writer = writer.clone_writer();
         Palette { brightness: Brightness::Dark, ..Default::default() }
           .with_child(fn_widget!{
-            $writer.write().push(Palette::of(ctx!()).brightness);
+            $writer.write().push(Palette::of(BuildCtx::get()).brightness);
             let writer = writer.clone_writer();
             Palette { brightness: Brightness::Light, ..Default::default() }
               .with_child(fn_widget!{
-                $writer.write().push(Palette::of(ctx!()).brightness);
+                $writer.write().push(Palette::of(BuildCtx::get()).brightness);
                 Void
             })
         })

--- a/core/src/builtin_widgets/theme/icon_theme.rs
+++ b/core/src/builtin_widgets/theme/icon_theme.rs
@@ -60,7 +60,7 @@ pub struct NamedSvg(pub usize);
 impl Compose for NamedSvg {
   fn compose(this: impl StateWriter<Value = Self>) -> Widget<'static> {
     fn_widget! {
-      pipe!($this.of_or_miss(ctx!()))
+      pipe!($this.of_or_miss(BuildCtx::get()))
     }
     .into_widget()
   }

--- a/core/src/builtin_widgets/theme/palette.rs
+++ b/core/src/builtin_widgets/theme/palette.rs
@@ -14,7 +14,7 @@ use super::*;
 ///
 /// let _w = Palette::default().with_child(fn_widget! {
 ///   // Every widget created in this scope can access the `Palette`.
-///   let _primary = Palette::of(ctx!()).primary();
+///   let _primary = Palette::of(BuildCtx::get()).primary();
 ///   Void
 /// });
 /// ```

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -5,7 +5,7 @@ mod widget_ctx;
 pub use layout_ctx::*;
 pub use widget_ctx::*;
 pub(crate) mod build_ctx;
-pub use build_ctx::{BuildCtx, BuildCtxHandle};
+pub use build_ctx::{BuildCtx, };
 pub mod app_ctx;
 #[cfg(feature = "tokio-async")]
 pub use app_ctx::tokio_async::*;

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -5,7 +5,7 @@ mod widget_ctx;
 pub use layout_ctx::*;
 pub use widget_ctx::*;
 pub(crate) mod build_ctx;
-pub use build_ctx::{BuildCtx, };
+pub use build_ctx::BuildCtx;
 pub mod app_ctx;
 #[cfg(feature = "tokio-async")]
 pub use app_ctx::tokio_async::*;

--- a/core/src/context/build_ctx.rs
+++ b/core/src/context/build_ctx.rs
@@ -4,7 +4,7 @@ use std::ptr::NonNull;
 use smallvec::SmallVec;
 use widget_id::{RenderQueryable, new_node};
 
-use crate::{local_sender::LocalSender, prelude::*, render_helper::PureRender};
+use crate::{local_sender::LocalSender, prelude::*};
 
 /// A context provide during build the widget tree.
 pub struct BuildCtx {

--- a/core/src/context/build_ctx.rs
+++ b/core/src/context/build_ctx.rs
@@ -4,9 +4,7 @@ use std::ptr::NonNull;
 use smallvec::SmallVec;
 use widget_id::{RenderQueryable, new_node};
 
-use crate::{
-  local_sender::LocalSender, pipe::DynInfo, prelude::*, render_helper::PureRender, window::WindowId,
-};
+use crate::{local_sender::LocalSender, prelude::*, render_helper::PureRender};
 
 /// A context provide during build the widget tree.
 pub struct BuildCtx {
@@ -16,65 +14,17 @@ pub struct BuildCtx {
   /// Providers are available for the preallocated widget but have not been
   /// attached yet.
   pub(crate) current_providers: SmallVec<[Box<dyn Query>; 1]>,
-  /// A node ID has already been allocated for the current building node.
-  pub(crate) pre_alloc: Option<WidgetId>,
   pub(crate) tree: NonNull<WidgetTree>,
   // Todo: Since `Theme`, `Palette`, `TypographyTheme` and `TextStyle` are frequently queried
   // during the building process, layout and paint. we should cache the closest one.
-}
-
-/// A handle of `BuildCtx` that you can store it and access the `BuildCtx` later
-/// in anywhere.
-#[derive(Debug, Clone)]
-pub struct BuildCtxHandle {
-  startup: StartUpWidget,
-  wnd_id: WindowId,
-}
-
-/// The widget from which to start creating the build context.
-#[derive(Debug, Clone)]
-enum StartUpWidget {
-  // The static widget ID.
-  Id(WidgetId),
-  // The pipe node info contains the widget ID. Since widgets may be regenerated,
-  // we use a lazy approach to retrieve it.
-  PipeNode(DynInfo),
 }
 
 impl BuildCtx {
   /// Return the window of this context is created from.
   pub fn window(&self) -> Sc<Window> { self.tree().window() }
 
-  /// Generate a handle for this `BuildCtx` that supports `Clone`, and
-  /// can be converted back to this `BuildCtx`. This allows you to store the
-  /// `BuildCtx`.
-  pub fn handle(&self) -> BuildCtxHandle {
-    // When the current widget is a pipe node. This widget ID may be updated in the
-    // future, so we store the pipe info to ensure we always retrieve the correct
-    // widget ID when using the handle.
-    //
-    // If the handle in the pipe subtree but not the pipe node (root), even
-    // though it will be regenerated, we can store the static widget ID because the
-    // handle will also be regenerated.
-    let id = *self.providers.last().unwrap();
-    let startup = if let Some(info) = self
-      .current_providers
-      .iter()
-      .find_map(|p| p.query(TypeId::of::<DynInfo>()))
-      .and_then(|h| h.into_ref())
-      .or_else(|| id.query_ref::<DynInfo>(self.tree()))
-    {
-      StartUpWidget::PipeNode(info.clone())
-    } else {
-      StartUpWidget::Id(id)
-    };
-
-    BuildCtxHandle { wnd_id: self.window().id(), startup }
-  }
-
-  #[inline]
-  pub(crate) fn create(startup: WidgetId, tree: NonNull<WidgetTree>) -> BuildCtxGuard {
-    BuildCtxGuard::new(startup, tree)
+  pub fn provider_handle(&self) -> ProviderHandle {
+    ProviderHandle { wnd_id: self.window().id(), widget: *self.providers.last().unwrap() }
   }
 
   pub(crate) fn tree(&self) -> &WidgetTree {
@@ -93,50 +43,7 @@ impl BuildCtx {
   }
 
   pub(crate) fn alloc(&mut self, node: Box<dyn RenderQueryable>) -> WidgetId {
-    if let Some(id) = self.pre_alloc.take() {
-      *id.get_node_mut(self.tree_mut()).unwrap() = node;
-      id
-    } else {
-      new_node(&mut self.tree_mut().arena, node)
-    }
-  }
-
-  pub(crate) fn pre_alloc(&mut self) -> WidgetId {
-    if let Some(id) = self.pre_alloc {
-      id
-    } else {
-      let id = new_node(&mut self.tree_mut().arena, Box::new(PureRender(Void)));
-      self.pre_alloc = Some(id);
-      id
-    }
-  }
-
-  pub(crate) fn consume_root_with_provider<'w>(
-    &mut self, w: Widget<'w>, provider: Box<dyn Query>,
-  ) -> (Widget<'w>, Box<dyn Query>) {
-    self.current_providers.push(provider);
-    let (w, _) = w.consume_root(self);
-    let provider = self.current_providers.pop().unwrap();
-    (w, provider)
-  }
-}
-
-impl BuildCtxHandle {
-  /// Acquires a reference to the `BuildCtx` in this handle, maybe not exist if
-  /// the window is closed or widget is removed.
-  ///
-  /// # Panic
-  ///
-  /// Panics if the widget node of the handle is removed.
-  pub fn with_ctx<R>(&self, f: impl FnOnce(&mut BuildCtx) -> R) -> Option<R> {
-    AppCtx::get_window(self.wnd_id).map(|wnd| {
-      let id = match &self.startup {
-        StartUpWidget::Id(id) => *id,
-        StartUpWidget::PipeNode(p) => p.borrow().host_id(),
-      };
-      let mut ctx = BuildCtx::create(id, wnd.tree);
-      f(&mut ctx)
-    })
+    new_node(&mut self.tree_mut().arena, node)
   }
 }
 
@@ -169,14 +76,19 @@ impl BuildCtx {
     }
   }
 
-  pub(crate) fn init_ctx(startup: WidgetId, tree: NonNull<WidgetTree>) -> BuildCtxInitdGuard {
+  pub(crate) fn set_ctx_for(startup: WidgetId, tree: NonNull<WidgetTree>) -> BuildCtxInitdGuard {
     let t = unsafe { tree.as_ref() };
-    let providers_list = startup.ancestors(t).filter(|id| id.queryable(t));
-
-    let mut providers: SmallVec<[WidgetId; 1]> = providers_list.collect();
+    let mut providers: SmallVec<[WidgetId; 1]> = startup
+      .ancestors(t)
+      .filter(|id| id.queryable(t))
+      .collect();
     providers.reverse();
-    let ctx = BuildCtx { tree, providers, pre_alloc: None, current_providers: <_>::default() };
+    let ctx = BuildCtx { tree, providers, current_providers: <_>::default() };
 
+    BuildCtx::set_ctx(ctx)
+  }
+
+  pub(crate) fn set_ctx(ctx: BuildCtx) -> BuildCtxInitdGuard {
     unsafe {
       assert!(CTX.is_none(), "Build context is already initialized");
       CTX = Some(LocalSender::new(ctx));
@@ -190,73 +102,4 @@ pub(crate) struct BuildCtxInitdGuard;
 
 impl Drop for BuildCtxInitdGuard {
   fn drop(&mut self) { unsafe { CTX = None } }
-}
-
-enum CtxRestore {
-  None,
-  Info { providers_len: usize, current_providers_len: usize },
-}
-pub(crate) struct BuildCtxGuard {
-  ctx: &'static mut BuildCtx,
-  restore: CtxRestore,
-}
-
-impl BuildCtxGuard {
-  pub(crate) fn new(startup: WidgetId, tree: NonNull<WidgetTree>) -> Self {
-    // Safety: The caller guarantees a valid tree structure.
-    let t = unsafe { tree.as_ref() };
-    let providers_list = startup.ancestors(t).filter(|id| id.queryable(t));
-
-    if let Some(ctx) = unsafe { CURRENT_CTX.as_mut() } {
-      let last = ctx.providers.last().copied();
-      let providers: SmallVec<[WidgetId; 1]> = providers_list
-        .take_while(|id| Some(*id) != last)
-        .collect();
-
-      let providers_len = ctx.providers.len();
-      let current_providers_len = ctx.current_providers.len();
-      ctx
-        .providers
-        .extend(providers.iter().rev().copied());
-
-      BuildCtxGuard { ctx, restore: CtxRestore::Info { providers_len, current_providers_len } }
-    } else {
-      let mut providers: SmallVec<[WidgetId; 1]> = providers_list.collect();
-      providers.reverse();
-
-      unsafe {
-        CURRENT_CTX =
-          Some(BuildCtx { tree, providers, pre_alloc: None, current_providers: <_>::default() });
-
-        BuildCtxGuard { ctx: CURRENT_CTX.as_mut().unwrap(), restore: CtxRestore::None }
-      }
-    }
-  }
-}
-
-impl std::ops::Deref for BuildCtxGuard {
-  type Target = BuildCtx;
-
-  fn deref(&self) -> &Self::Target { &*self.ctx }
-}
-
-impl std::ops::DerefMut for BuildCtxGuard {
-  fn deref_mut(&mut self) -> &mut Self::Target { self.ctx }
-}
-
-impl Drop for BuildCtxGuard {
-  fn drop(&mut self) {
-    match self.restore {
-      CtxRestore::None => unsafe { CURRENT_CTX = None },
-      CtxRestore::Info { providers_len, current_providers_len } => {
-        assert!(self.ctx.providers.len() >= providers_len);
-        assert!(self.ctx.current_providers.len() >= current_providers_len);
-        self.ctx.providers.drain(providers_len..);
-        self
-          .ctx
-          .current_providers
-          .drain(current_providers_len..);
-      }
-    }
-  }
 }

--- a/core/src/declare.rs
+++ b/core/src/declare.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 
 use rxrust::ops::box_it::BoxOp;
 
-use crate::{context::BuildCtx, pipe::Pipe, prelude::BoxPipe, state::ModifyScope};
+use crate::{pipe::Pipe, prelude::BoxPipe, state::ModifyScope};
 
 /// Trait used to create a widget declarer that can interact with the `BuildCtx`
 /// to create a widget.
@@ -16,7 +16,7 @@ pub trait Declare {
 pub trait ObjDeclarer {
   type Target;
   /// Finish the object creation with the given context.
-  fn finish(self, ctx: &BuildCtx) -> Self::Target;
+  fn finish(self) -> Self::Target;
 }
 
 /// Used to do conversion from a value to the `DeclareInit` type.

--- a/core/src/events/character.rs
+++ b/core/src/events/character.rs
@@ -74,9 +74,7 @@ mod tests {
         }
       }
     };
-    let mut wnd = TestWindow::new(fn_widget! {
-      widget.clone()(ctx!())
-    });
+    let mut wnd = TestWindow::new(move || widget.clone().into_widget());
 
     let test_text_case = "123";
     wnd.draw_frame();

--- a/core/src/events/wheel.rs
+++ b/core/src/events/wheel.rs
@@ -59,7 +59,7 @@ mod tests {
     };
 
     let mut wnd =
-      TestWindow::new_with_size(fn_widget! { widget.clone()(ctx!()) }, Size::new(100., 100.));
+      TestWindow::new_with_size(move || widget.clone().into_widget(), Size::new(100., 100.));
 
     wnd.draw_frame();
     let device_id = unsafe { DeviceId::dummy() };

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -174,7 +174,7 @@ impl Overlay {
     if let Some(showing) = showing {
       let ShowingInfo { id, wnd_id, .. } = showing;
       if let Some(wnd) = AppCtx::get_window(wnd_id) {
-        let _guard = BuildCtx::init_ctx(wnd.tree().root(), wnd.tree);
+        let _guard = BuildCtx::set_ctx_for(wnd.tree().root(), wnd.tree);
         let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
         showing_overlays.remove(self);
 
@@ -214,7 +214,7 @@ impl Overlay {
       }
     };
 
-    let _guard = BuildCtx::init_ctx(wnd.tree().root(), wnd.tree);
+    let _guard = BuildCtx::set_ctx_for(wnd.tree().root(), wnd.tree);
     let ctx = BuildCtx::get_mut();
     let id = gen(ctx).build(ctx);
     self.0.borrow_mut().showing = Some(ShowingInfo { id, generator: gen.into(), wnd_id: wnd.id() });

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -215,11 +215,10 @@ impl Overlay {
     };
 
     let _guard = BuildCtx::set_ctx_for(wnd.tree().root(), wnd.tree);
-    let ctx = BuildCtx::get_mut();
-    let id = gen(ctx).build(ctx);
+    let id = gen(BuildCtx::get_mut()).build();
     self.0.borrow_mut().showing = Some(ShowingInfo { id, generator: gen.into(), wnd_id: wnd.id() });
 
-    let showing_overlays = Provider::of::<ShowingOverlays>(&*ctx).unwrap();
+    let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
     showing_overlays.add(self.clone());
 
     let tree = wnd.tree_mut();
@@ -234,14 +233,14 @@ impl Overlay {
 pub(crate) struct ShowingOverlays(RefCell<Vec<Overlay>>);
 
 impl ShowingOverlays {
-  pub(crate) fn rebuild(&self, ctx: &mut BuildCtx) {
+  pub(crate) fn rebuild(&self) {
     for o in self.0.borrow().iter() {
       let mut o = o.0.borrow_mut();
       let ShowingInfo { id, generator, .. } = o.showing.as_mut().unwrap();
 
-      id.dispose_subtree(ctx.tree_mut());
-      *id = generator.gen_widget().build(ctx);
-      let tree = ctx.tree_mut();
+      let tree = BuildCtx::get_mut().tree_mut();
+      id.dispose_subtree(tree);
+      *id = generator.gen_widget().build();
       tree.root().append(*id, tree);
       id.on_mounted_subtree(tree);
     }

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -123,11 +123,9 @@ impl Overlay {
   ///       let wid = wid.clone();
   ///       overlay.show_map(move |w| {
   ///         let wid = wid.clone();
-  ///         fn_widget! {
-  ///           let mut w = FatObj::new(w);
-  ///           w.left_align_to(&wid, 0., ctx!());
-  ///           w
-  ///         }.into_widget()
+  ///         let mut w = FatObj::new(w);
+  ///         w.left_align_to(&wid, 0.);
+  ///         w.into_widget()
   ///        },
   ///        e.window()
   ///       );
@@ -145,7 +143,7 @@ impl Overlay {
       return;
     }
     let gen = self.0.borrow().gen.clone();
-    let gen = move |_: &mut BuildCtx| f(gen.gen_widget());
+    let gen = move || f(gen.gen_widget());
     self.inner_show(gen.into(), wnd);
   }
 
@@ -174,7 +172,7 @@ impl Overlay {
     if let Some(showing) = showing {
       let ShowingInfo { id, wnd_id, .. } = showing;
       if let Some(wnd) = AppCtx::get_window(wnd_id) {
-        let _guard = BuildCtx::set_ctx_for(wnd.tree().root(), wnd.tree);
+        let _guard = BuildCtx::init_for(wnd.tree().root(), wnd.tree);
         let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
         showing_overlays.remove(self);
 
@@ -214,8 +212,8 @@ impl Overlay {
       }
     };
 
-    let _guard = BuildCtx::set_ctx_for(wnd.tree().root(), wnd.tree);
-    let id = gen(BuildCtx::get_mut()).build();
+    let _guard = BuildCtx::init_for(wnd.tree().root(), wnd.tree);
+    let id = gen().build();
     self.0.borrow_mut().showing = Some(ShowingInfo { id, generator: gen.into(), wnd_id: wnd.id() });
 
     let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -174,8 +174,8 @@ impl Overlay {
     if let Some(showing) = showing {
       let ShowingInfo { id, wnd_id, .. } = showing;
       if let Some(wnd) = AppCtx::get_window(wnd_id) {
-        let ctx = BuildCtx::create(wnd.tree().root(), wnd.tree);
-        let showing_overlays = Provider::of::<ShowingOverlays>(&*ctx).unwrap();
+        let _guard = BuildCtx::init_ctx(wnd.tree().root(), wnd.tree);
+        let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
         showing_overlays.remove(self);
 
         let tree = wnd.tree_mut();
@@ -214,8 +214,9 @@ impl Overlay {
       }
     };
 
-    let mut ctx = BuildCtx::create(wnd.tree().root(), wnd.tree);
-    let id = gen(&mut ctx).build(&mut ctx);
+    let _guard = BuildCtx::init_ctx(wnd.tree().root(), wnd.tree);
+    let ctx = BuildCtx::get_mut();
+    let id = gen(ctx).build(ctx);
     self.0.borrow_mut().showing = Some(ShowingInfo { id, generator: gen.into(), wnd_id: wnd.id() });
 
     let showing_overlays = Provider::of::<ShowingOverlays>(&*ctx).unwrap();

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -98,10 +98,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
       let priority = UpdatePriority::new_with_wnd(info.clone(), ctx.window().id());
       let (w, modifies) = self.unzip(ModifyScope::FRAMEWORK, Some(Box::new(priority)));
 
-      let provider = Box::new(Queryable(info.clone()));
-      let (w, _) = ctx.consume_root_with_provider(w.into_widget(), provider);
-
-      w.on_build(|w, ctx| {
+      w.into_widget().on_build(|w, ctx| {
         info
           .borrow_mut()
           .set_gen_range(GenRange::Single(w));
@@ -113,7 +110,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
         let u = modifies.subscribe(move |(_, w)| {
           let info = pipe_node.dyn_info();
           let old = info.borrow().host_id();
-          let _guard = BuildCtx::init_ctx(old, tree);
+          let _guard = BuildCtx::set_ctx_for(old, tree);
 
           let ctx = BuildCtx::get_mut();
           let old_node = pipe_node.remove_old_data();
@@ -152,12 +149,6 @@ pub(crate) trait InnerPipe: Pipe + Sized {
       .next()
       .map_or_else(|| Void.into_widget(), IntoWidget::into_widget);
 
-    let provider = Box::new(Queryable(info.clone()));
-    let first = fn_widget! {
-      let (w, _) = ctx!().consume_root_with_provider(first, provider);
-      w
-    };
-
     let info2 = info.clone();
     let first = first.into_widget().on_build(move |id, ctx| {
       match &mut info2.borrow_mut().gen_range {
@@ -177,7 +168,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
           _ => unreachable!(),
         };
 
-        let _guard = BuildCtx::init_ctx(old[0], tree);
+        let _guard = BuildCtx::set_ctx_for(old[0], tree);
         let ctx = BuildCtx::get_mut();
 
         let old_node = pipe_node.remove_old_data();
@@ -249,9 +240,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
       let priority = UpdatePriority::new_with_wnd(info.clone(), ctx.window().id());
       let (w, modifies) = self.unzip(ModifyScope::FRAMEWORK, Some(Box::new(priority)));
 
-      let provider = Box::new(Queryable(info.clone()));
-      let (w, _) = ctx.consume_root_with_provider(w.into_widget(), provider);
-      w.on_build(|p, ctx| {
+      w.into_widget().on_build(|p, ctx| {
         let pipe_node = PipeNode::share_capture(p, info.clone(), ctx);
         let tree = ctx.tree_mut();
         let leaf = p.single_leaf(tree);
@@ -275,7 +264,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
             _ => unreachable!(),
           };
 
-          let _guard = BuildCtx::init_ctx(top, tree);
+          let _guard = BuildCtx::set_ctx_for(top, tree);
           let ctx = BuildCtx::get_mut();
 
           let old_node = pipe_node.remove_old_data();

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -114,7 +114,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
 
           let ctx = BuildCtx::get_mut();
           let old_node = pipe_node.remove_old_data();
-          let new = w.into_widget().build(ctx);
+          let new = w.into_widget().build();
           let tree = ctx.tree_mut();
           pipe_node.transplant_to_new(old_node, new, tree);
 
@@ -169,20 +169,18 @@ pub(crate) trait InnerPipe: Pipe + Sized {
         };
 
         let _guard = BuildCtx::set_ctx_for(old[0], tree);
-        let ctx = BuildCtx::get_mut();
-
+        let tree = BuildCtx::get_mut().tree_mut();
         let old_node = pipe_node.remove_old_data();
         let mut new = vec![];
         for (idx, w) in m.into_iter().enumerate() {
-          let id = w.into_widget().build(ctx);
+          let id = w.into_widget().build();
           new.push(id);
-          set_pos_of_multi(id, idx, ctx.tree());
+          set_pos_of_multi(id, idx, tree);
         }
         if new.is_empty() {
-          new.push(Void.into_widget().build(ctx));
+          new.push(Void.into_widget().build());
         }
 
-        let tree = ctx.tree_mut();
         pipe_node.transplant_to_new(old_node, new[0], tree);
 
         query_outside_infos(new[0], &info, tree)
@@ -268,7 +266,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
           let ctx = BuildCtx::get_mut();
 
           let old_node = pipe_node.remove_old_data();
-          let p = w.into_widget().build(ctx);
+          let p = w.into_widget().build();
           let tree = ctx.tree_mut();
           pipe_node.transplant_to_new(old_node, p, tree);
 

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -113,10 +113,11 @@ pub(crate) trait InnerPipe: Pipe + Sized {
         let u = modifies.subscribe(move |(_, w)| {
           let info = pipe_node.dyn_info();
           let old = info.borrow().host_id();
-          let mut ctx = BuildCtx::create(old, tree);
+          let _guard = BuildCtx::init_ctx(old, tree);
 
+          let ctx = BuildCtx::get_mut();
           let old_node = pipe_node.remove_old_data();
-          let new = w.into_widget().build(&mut ctx);
+          let new = w.into_widget().build(ctx);
           let tree = ctx.tree_mut();
           pipe_node.transplant_to_new(old_node, new, tree);
 
@@ -176,17 +177,18 @@ pub(crate) trait InnerPipe: Pipe + Sized {
           _ => unreachable!(),
         };
 
-        let mut ctx = BuildCtx::create(old[0], tree);
+        let _guard = BuildCtx::init_ctx(old[0], tree);
+        let ctx = BuildCtx::get_mut();
 
         let old_node = pipe_node.remove_old_data();
         let mut new = vec![];
         for (idx, w) in m.into_iter().enumerate() {
-          let id = w.into_widget().build(&mut ctx);
+          let id = w.into_widget().build(ctx);
           new.push(id);
           set_pos_of_multi(id, idx, ctx.tree());
         }
         if new.is_empty() {
-          new.push(Void.into_widget().build(&mut ctx));
+          new.push(Void.into_widget().build(ctx));
         }
 
         let tree = ctx.tree_mut();
@@ -273,10 +275,11 @@ pub(crate) trait InnerPipe: Pipe + Sized {
             _ => unreachable!(),
           };
 
-          let mut ctx = BuildCtx::create(top, tree);
+          let _guard = BuildCtx::init_ctx(top, tree);
+          let ctx = BuildCtx::get_mut();
 
           let old_node = pipe_node.remove_old_data();
-          let p = w.into_widget().build(&mut ctx);
+          let p = w.into_widget().build(ctx);
           let tree = ctx.tree_mut();
           pipe_node.transplant_to_new(old_node, p, tree);
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -399,9 +399,7 @@ where
         Err(s) => {
           let modifies = s.raw_modifies();
           let w = ReaderRender(s.clone_reader()).into_widget();
-          w.on_build(move |id, ctx| {
-            id.dirty_subscribe(modifies, ctx);
-          })
+          w.on_build(move |id| id.dirty_subscribe(modifies, BuildCtx::get_mut().tree_mut()))
         }
       },
     }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -195,7 +195,8 @@ impl<'w> Widget<'w> {
   }
 
   /// Build the root node of the widget only.
-  pub(crate) fn consume_root(self, ctx: &mut BuildCtx) -> (Self, WidgetId) {
+  pub(crate) fn consume_root(self) -> (Self, WidgetId) {
+    let ctx = BuildCtx::get_mut();
     let mut root_id = None;
     let node = self.into_node(ctx).wrap_root(|n| {
       let id = n.alloc(ctx);

--- a/core/src/widget_children/child_convert.rs
+++ b/core/src/widget_children/child_convert.rs
@@ -1,4 +1,4 @@
-use crate::{context::BuildCtx, pipe::*, widget::*};
+use crate::{pipe::*, widget::*};
 
 /// Trait for conversions type as a child of widget.
 ///
@@ -21,7 +21,7 @@ impl<C> IntoChild<Option<C>, SELF> for C {
   fn into_child(self) -> Option<C> { Some(self) }
 }
 
-impl<F: FnMut(&mut BuildCtx) -> Widget<'static> + 'static> IntoChild<GenWidget, 0> for F {
+impl<F: FnMut() -> Widget<'static> + 'static> IntoChild<GenWidget, 0> for F {
   #[inline]
   fn into_child(self) -> GenWidget { GenWidget::new(self) }
 }
@@ -89,7 +89,7 @@ impl<P: Pipe> IntoChild<BoxPipe<P::Value>, 0> for P {
 
 impl<'w, F> IntoChild<FnWidget<'w>, FN> for F
 where
-  F: FnOnce(&mut BuildCtx) -> Widget<'w> + 'w,
+  F: FnOnce() -> Widget<'w> + 'w,
 {
   #[inline]
   fn into_child(self) -> FnWidget<'w> { Box::new(self) }

--- a/core/src/widget_children/compose_child_impl.rs
+++ b/core/src/widget_children/compose_child_impl.rs
@@ -177,8 +177,9 @@ where
   fn with_child(self, child: C) -> Self::Target {
     let host = child.into_widget();
 
-    let f = move |ctx: &mut BuildCtx| {
+    let f = move || {
       let tid = TypeId::of::<W>();
+      let ctx = BuildCtx::get();
       let decor = ctx
         .all_providers::<ComposeDecorators>()
         .find_map(|t| QueryRef::filter_map(t, |t| t.styles.get(&tid)).ok());

--- a/core/src/widget_children/multi_child_impl.rs
+++ b/core/src/widget_children/multi_child_impl.rs
@@ -103,7 +103,7 @@ impl<'w> WithChild<'w, Widget<'w>, 1, FN> for MultiPair<'w> {
 
 impl<'w> IntoWidgetStrict<'w, FN> for MultiPair<'w> {
   fn into_widget_strict(self) -> Widget<'w> {
-    let f = move |ctx: &mut BuildCtx| {
+    let f = move || {
       let MultiPair { parent, children } = self;
       parent.directly_compose_children(children)
     };

--- a/core/src/widget_children/multi_child_impl.rs
+++ b/core/src/widget_children/multi_child_impl.rs
@@ -105,7 +105,7 @@ impl<'w> IntoWidgetStrict<'w, FN> for MultiPair<'w> {
   fn into_widget_strict(self) -> Widget<'w> {
     let f = move |ctx: &mut BuildCtx| {
       let MultiPair { parent, children } = self;
-      parent.directly_compose_children(children, ctx)
+      parent.directly_compose_children(children)
     };
 
     f.into_widget()

--- a/core/src/widget_children/single_child_impl.rs
+++ b/core/src/widget_children/single_child_impl.rs
@@ -50,7 +50,7 @@ where
 
 impl<'w, W: SingleIntoParent> IntoWidgetStrict<'w, RENDER> for WidgetOf<'w, W> {
   fn into_widget_strict(self) -> Widget<'w> {
-    let f = move |ctx: &mut BuildCtx| {
+    let f = move || {
       let Pair { parent, child } = self;
 
       parent
@@ -153,7 +153,7 @@ where
 fn option_pipe_into_parent<const M: usize>(
   p: impl InnerPipe<Value = Option<impl IntoWidget<'static, M>>>,
 ) -> Widget<'static> {
-  p.map(|w| move |_: &mut BuildCtx| w.map_or_else(|| Void.into_widget(), IntoWidget::into_widget))
+  p.map(|w| w.map_or_else(|| Void.into_widget(), IntoWidget::into_widget))
     .into_parent_widget()
 }
 #[cfg(test)]

--- a/core/src/widget_children/single_child_impl.rs
+++ b/core/src/widget_children/single_child_impl.rs
@@ -55,7 +55,7 @@ impl<'w, W: SingleIntoParent> IntoWidgetStrict<'w, RENDER> for WidgetOf<'w, W> {
 
       parent
         .into_parent()
-        .directly_compose_children(vec![child], ctx)
+        .directly_compose_children(vec![child])
     };
 
     f.into_widget()

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -32,23 +32,20 @@ impl WidgetTree {
       current_providers: <_>::default(),
     });
 
-    let ctx = BuildCtx::get_mut();
-
     let theme = AppCtx::app_theme().clone_writer();
     let overlays = Queryable(ShowingOverlays::default());
     let root = Provider::new(Box::new(overlays))
       .with_child(fn_widget! {
         theme.with_child(fn_widget!{
-          let ctx = unsafe { &*(ctx!() as *mut BuildCtx) };
-          let overlays = Provider::of::<ShowingOverlays>(ctx).unwrap();
-          overlays.rebuild(ctx!());
+          let overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
+          overlays.rebuild();
           @Root {
             @{ content.gen_widget() }
           }
         })
       })
       .into_widget()
-      .build(ctx);
+      .build();
 
     self.root = root;
     self.mark_dirty(root);

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -26,7 +26,7 @@ type TreeArena = Arena<Box<dyn RenderQueryable>>;
 impl WidgetTree {
   pub fn init(&mut self, wnd: &Window, content: GenWidget) -> WidgetId {
     self.root.0.remove_subtree(&mut self.arena);
-    let _guard = BuildCtx::set_ctx(BuildCtx {
+    let _guard = BuildCtx::init(BuildCtx {
       tree: wnd.tree,
       providers: <_>::default(),
       current_providers: <_>::default(),

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -26,7 +26,8 @@ type TreeArena = Arena<Box<dyn RenderQueryable>>;
 impl WidgetTree {
   pub fn init(&mut self, wnd: &Window, content: GenWidget) -> WidgetId {
     let root = self.root;
-    let mut ctx = BuildCtx::create(root, wnd.tree);
+    let _guard = BuildCtx::init_ctx(root, wnd.tree);
+    let ctx = BuildCtx::get_mut();
     ctx.pre_alloc = Some(root);
 
     let theme = AppCtx::app_theme().clone_writer();
@@ -43,7 +44,7 @@ impl WidgetTree {
         })
       })
       .into_widget()
-      .build(&mut ctx);
+      .build(ctx);
 
     assert_eq!(root, id);
 

--- a/core/src/widget_tree/widget_id.rs
+++ b/core/src/widget_tree/widget_id.rs
@@ -38,9 +38,9 @@ impl WidgetId {
   /// Subscribe the modifies `upstream` to mark the widget dirty when the
   /// `upstream` emit a modify event that contains `ModifyScope::FRAMEWORK`.
   pub(crate) fn dirty_subscribe(
-    self, upstream: CloneableBoxOp<'static, ModifyScope, Infallible>, ctx: &mut BuildCtx,
+    self, upstream: CloneableBoxOp<'static, ModifyScope, Infallible>, tree: &mut WidgetTree,
   ) {
-    let dirty_set = ctx.tree().dirty_set.clone();
+    let dirty_set = tree.dirty_set.clone();
     let h = upstream
       .filter(|b| b.contains(ModifyScope::FRAMEWORK))
       .subscribe(move |_| {
@@ -48,7 +48,7 @@ impl WidgetId {
       })
       .unsubscribe_when_dropped();
 
-    self.attach_anonymous_data(h, ctx.tree_mut());
+    self.attach_anonymous_data(h, tree);
   }
 
   pub(crate) fn get_node_mut(self, tree: &mut WidgetTree) -> Option<&mut Box<dyn RenderQueryable>> {

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -208,7 +208,7 @@ impl Window {
       let root = self.tree().root();
 
       let surface = {
-        let _guard = BuildCtx::set_ctx_for(root, self.tree);
+        let _guard = BuildCtx::init_for(root, self.tree);
         Palette::of(BuildCtx::get()).surface()
       };
       self.shell_wnd.borrow_mut().begin_frame(surface);
@@ -302,13 +302,10 @@ impl Window {
 
   pub fn init(&self, content: GenWidget) {
     let root = self.tree_mut().init(self, content);
-    let _guard = BuildCtx::set_ctx_for(root, self.tree);
+    let _guard = BuildCtx::init_for(root, self.tree);
     let ctx = BuildCtx::get();
-    let brush = Palette::of(&*ctx).on_surface_variant();
-    let text_style = TypographyTheme::of(&*ctx)
-      .body_medium
-      .text
-      .clone();
+    let brush = Palette::of(ctx).on_surface_variant();
+    let text_style = TypographyTheme::of(ctx).body_medium.text.clone();
     self
       .painter
       .borrow_mut()

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -208,8 +208,8 @@ impl Window {
       let root = self.tree().root();
 
       let surface = {
-        let ctx = BuildCtx::create(root, self.tree);
-        Palette::of(&*ctx).surface()
+        let _guard = BuildCtx::init_ctx(root, self.tree);
+        Palette::of(BuildCtx::get()).surface()
       };
       self.shell_wnd.borrow_mut().begin_frame(surface);
 
@@ -302,7 +302,8 @@ impl Window {
 
   pub fn init(&self, content: GenWidget) {
     let root = self.tree_mut().init(self, content);
-    let ctx = BuildCtx::create(root, self.tree);
+    let _guard = BuildCtx::init_ctx(root, self.tree);
+    let ctx = BuildCtx::get();
     let brush = Palette::of(&*ctx).on_surface_variant();
     let text_style = TypographyTheme::of(&*ctx)
       .body_medium

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -208,7 +208,7 @@ impl Window {
       let root = self.tree().root();
 
       let surface = {
-        let _guard = BuildCtx::init_ctx(root, self.tree);
+        let _guard = BuildCtx::set_ctx_for(root, self.tree);
         Palette::of(BuildCtx::get()).surface()
       };
       self.shell_wnd.borrow_mut().begin_frame(surface);
@@ -302,7 +302,7 @@ impl Window {
 
   pub fn init(&self, content: GenWidget) {
     let root = self.tree_mut().init(self, content);
-    let _guard = BuildCtx::init_ctx(root, self.tree);
+    let _guard = BuildCtx::set_ctx_for(root, self.tree);
     let ctx = BuildCtx::get();
     let brush = Palette::of(&*ctx).on_surface_variant();
     let text_style = TypographyTheme::of(&*ctx)

--- a/core/src/wrap_render.rs
+++ b/core/src/wrap_render.rs
@@ -35,9 +35,10 @@ pub trait WrapRender {
   where
     Self: Sized + 'static,
   {
-    child.on_build(move |id, ctx| {
+    child.on_build(move |id| {
       let mut modifies = None;
-      id.wrap_node(ctx.tree_mut(), |r| match this.try_into_value() {
+      let tree = BuildCtx::get_mut().tree_mut();
+      id.wrap_node(tree, |r| match this.try_into_value() {
         Ok(this) => Box::new(RenderPair { wrapper: Box::new(this), host: r }),
         Err(this) => {
           let reader = match this.into_reader() {
@@ -51,7 +52,7 @@ pub trait WrapRender {
         }
       });
       if let Some(modifies) = modifies {
-        id.dirty_subscribe(modifies, ctx);
+        id.dirty_subscribe(modifies, tree);
       }
     })
   }

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -43,7 +43,7 @@ A function widget can be defined directly through a function:
 ```rust no_run
 use ribir::prelude::*;
 
-fn hello_world(ctx!(): &mut BuildCtx) -> Widget<'static> {
+fn hello_world() -> Widget<'static> {
   rdl!{ Text { text: "Hello World!" } }
     .into_widget()
 }
@@ -72,7 +72,7 @@ Because `hello_world` is not called by anyone else, you can rewrite it as a clos
 use ribir::prelude::*;
 
 fn main() {
-  let hello_world = |ctx!(): &mut BuildCtx| {
+  let hello_world = || {
     rdl!{ Text { text: "Hello World!" } }
       .into_widget()
   };
@@ -128,9 +128,8 @@ pub struct Counter {
   #[declare(default = 1usize)]
   count: usize,
 }
-// `rdl!` only allow to be used in a context with `ctx!(): &BuildCtx` accessible.
-// So we use a function with `ctx!()` parameter to provide this context.
-fn use_rdl(ctx!(): &BuildCtx) {
+
+fn use_rdl() {
   let _ = rdl!{ Counter { } };
 }
 ```

--- a/docs/en/understanding_ribir/without_dsl.md
+++ b/docs/en/understanding_ribir/without_dsl.md
@@ -67,7 +67,7 @@ fn button_demo(ctx: &BuildCtx) {
   let btn: FatObj<State<FilledButton>> = FilledButton::declarer()
     .color(Color::RED)
     .on_tap(|_| println!("Button clicked"))
-    .finish(ctx);
+    .finish();
 }
 ```
 
@@ -101,10 +101,10 @@ Another thing to note is that we're creating `FatObj<State<FilledButton>>`, not 
 ```rust
 use ribir::prelude::*;
 
-fn button_demo(ctx: &BuildCtx){
+fn button_demo(_: &BuildCtx){
   let mut btn: FatObj<State<FilledButton>> = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx);
+    .finish();
 
   let w = btn.clone_writer();
   btn = btn.on_tap(move |_| w.write().color = Color::BLUE);
@@ -121,11 +121,11 @@ Another benefit of using `Declare` to create widgets is that it allows for prope
 use ribir::prelude::*;
 
 fn button_demo(ctx: &BuildCtx){
-  let btn1 = FilledButton::declarer().color(Color::RED).finish(ctx);
+  let btn1 = FilledButton::declarer().color(Color::RED).finish();
 
   let btn2 = FilledButton::declarer()
     .color(pipe!($btn1.color))
-    .finish(ctx);
+    .finish();
 
   btn1.write().color = Color::BLUE;
 }
@@ -143,7 +143,7 @@ use ribir::prelude::*;
 fn button_demo(ctx: &BuildCtx){
   let mut btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx);
+    .finish();
 
   let m = btn.get_margin_widget().clone_writer();
   btn = btn.on_tap(move |_| m.write().margin = EdgeInsets::all(10.0));
@@ -165,12 +165,12 @@ use ribir::prelude::*;
 fn button_demo(ctx: &BuildCtx) {
   let text_btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx)
+    .finish()
     .with_child(Label::new("Text Button"));
 
   let icon_btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx)
+    .finish()
     .with_child(svgs::ADD);
 }
 ```

--- a/docs/en/understanding_ribir/without_dsl.md
+++ b/docs/en/understanding_ribir/without_dsl.md
@@ -84,12 +84,12 @@ use ribir::prelude::*;
 
 #[derive(Declare, Default)]
 pub struct FilledButton {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   pub color: Color,
 }
 ```
 
-Note the attribute `#[declare(default=Palette::of(ctx!()).primary())]`. This means that if you don't set a `color` value when creating `FilledButton` with `Declare`, it will use the primary color from the palette as the default.
+Note the attribute `#[declare(default=Palette::of(BuildCtx::get()).primary())]`. This means that if you don't set a `color` value when creating `FilledButton` with `Declare`, it will use the primary color from the palette as the default.
 
 This is the main reason we use `Declare` to create widgets: it allows widgets to access `BuildCtx` when they're created. This lets widgets automatically configure themselves based on the context, like changing dynamically with the theme.
 
@@ -186,12 +186,12 @@ let counter = fn_widget! {
   let cnt = Stateful::new(0);
   let btn = FilledButton::declarer()
     .on_tap(move |_| *$cnt.write() += 1)
-    .finish(ctx!())
+    .finish()
     .with_child(Label::new("Inc"));
 
   let label = H1::declarer()
     .text(pipe!($cnt.to_string()))
-    .finish(ctx!());
+    .finish();
 
   @Row {
     @ { btn }

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -43,7 +43,7 @@ sidebar_position: 2
 ```rust no_run
 use ribir::prelude::*;
 
-fn hello_world(ctx!(): &mut BuildCtx) -> Widget<'static> {
+fn hello_world() -> Widget<'static> {
   rdl!{ Text { text: "Hello World!" } }
     .into_widget()
 }
@@ -53,9 +53,7 @@ fn main() {
 }
 ```
 
-首先，你应该发现了在函数签名中参数声明（`ctx!(): &BuildCtx`）的不同之处，我们用 `ctx!()` 来作为参数名字，而不是直接给一个名字。这是因为 `rdl!` 内部会统一通过 `ctx!()` 作为变量名来引用 `&BuildCtx`。
-
-接下来一行 `rdl!{ Text { text: "Hello World!" } }`，通过 `rdl！` 创建了一个内容为 `Hello World!` 的 `Text`。关于 `rdl!` 的细节，你可以先放到一边，将在小节 [使用 `rdl!` 创建对象](#使用-rdl-创建对象) 中详细介绍。
+`rdl!{ Text { text: "Hello World!" } }`，通过 `rdl！` 创建了一个内容为 `Hello World!` 的 `Text`。关于 `rdl!` 的细节，你可以先放到一边，将在小节 [使用 `rdl!` 创建对象](#使用-rdl-创建对象) 中详细介绍。
 
 最后，将 `Text` 通过 `build` 方法构建成 `Widget`，作为函数的返回值。
 
@@ -71,7 +69,7 @@ fn main() {
 use ribir::prelude::*;
 
 fn main() {
-  let hello_world = |ctx!(): &mut BuildCtx| {
+  let hello_world = || {
     rdl!{ Text { text: "Hello World!" } }
       .into_widget()
   };
@@ -82,7 +80,7 @@ fn main() {
 对于通过闭包创建函数控件，Ribir 提供了一个 `fn_widget!` 宏来简化这个过程，`fn_widget!` 除了支持我们本章接下来要讲到的两个语法糖 `@` 和 `$` 之外，你可以简单认为它会这样展开代码：
 
 ``` rust ignore
-move |ctx!(): &BuildCtx| -> Widget {
+move || -> Widget {
   {
     // 你的代码
   }
@@ -128,9 +126,7 @@ pub struct Counter {
   count: usize,
 }
 
-// `rdl!` 需要在一个有可访问的 `ctx!(): &BuildCtx` 的上下文中使用,
-// 所以我们用一个带 `ctx!()` 参数的函数来提供这个上下文。
-fn use_rdl(ctx!(): &BuildCtx) {
+fn use_rdl() {
   let _ = rdl!{ Counter { } };
 }
 ```

--- a/docs/zh/understanding_ribir/without_dsl.md
+++ b/docs/zh/understanding_ribir/without_dsl.md
@@ -84,12 +84,12 @@ use ribir::prelude::*;
 
 #[derive(Declare, Default)]
 pub struct FilledButton {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   pub color: Color,
 }
 ```
 
-需要注意的是，它有一个 attribute：`#[declare(default=Palette::of(ctx!()).primary())]`。这意味着，如果在使用 `Declare` 创建 `FilledButton` 时，没有设置 `color` 值，那么将使用调色板的主色作为默认值。
+需要注意的是，它有一个 attribute：`#[declare(default=Palette::of(BuildCtx::get()).primary())]`。这意味着，如果在使用 `Declare` 创建 `FilledButton` 时，没有设置 `color` 值，那么将使用调色板的主色作为默认值。
 
 这就是我们为何要通过 `Declare` 创建控件的首要原因：它允许控件在创建时访问 `BuildCtx`，使得控件能够根据上下文自动配置，例如，随着主题的变化而动态变化。
 
@@ -119,7 +119,7 @@ fn button_demo(ctx: &BuildCtx){
 ```rust
 use ribir::prelude::*;
 
-fn button_demo(ctx: &BuildCtx){
+fn button_demo(){
   let btn1 = FilledButton::declarer().color(Color::RED).finish();
 
   let btn2 = FilledButton::declarer()
@@ -139,7 +139,7 @@ fn button_demo(ctx: &BuildCtx){
 ```rust
 use ribir::prelude::*;
 
-fn button_demo(ctx: &BuildCtx){
+fn button_demo(){
   let mut btn = FilledButton::declarer()
     .color(Color::RED)
     .finish();
@@ -161,15 +161,15 @@ fn button_demo(ctx: &BuildCtx){
 ```rust
 use ribir::prelude::*;
 
-fn button_demo(ctx: &BuildCtx){
+fn button_demo(){
   let text_btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx)
+    .finish()
     .with_child(Label::new("Text Button"));
 
   let icon_btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx)
+    .finish()
     .with_child(svgs::ADD);
 }
 ```
@@ -185,12 +185,12 @@ let counter = fn_widget! {
   let cnt = Stateful::new(0);
   let btn = FilledButton::declarer()
     .on_tap(move |_| *$cnt.write() += 1)
-    .finish(ctx!())
+    .finish()
     .with_child(Label::new("Inc"));
 
   let label = H1::declarer()
     .text(pipe!($cnt.to_string()))
-    .finish(ctx!());
+    .finish();
 
   @Row {
     @ { btn }

--- a/docs/zh/understanding_ribir/without_dsl.md
+++ b/docs/zh/understanding_ribir/without_dsl.md
@@ -67,7 +67,7 @@ fn button_demo(ctx: &BuildCtx) {
   let btn: FatObj<State<FilledButton>> = FilledButton::declarer()
     .color(Color::RED)
     .on_tap(|_| println!("Button clicked"))
-    .finish(ctx);
+    .finish();
 }
 ```
 
@@ -103,7 +103,7 @@ use ribir::prelude::*;
 fn button_demo(ctx: &BuildCtx){
   let mut btn: FatObj<State<FilledButton>> = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx);
+    .finish();
 
   let w = btn.clone_writer();
   btn = btn.on_tap(move |_| w.write().color = Color::BLUE);
@@ -120,11 +120,11 @@ fn button_demo(ctx: &BuildCtx){
 use ribir::prelude::*;
 
 fn button_demo(ctx: &BuildCtx){
-  let btn1 = FilledButton::declarer().color(Color::RED).finish(ctx);
+  let btn1 = FilledButton::declarer().color(Color::RED).finish();
 
   let btn2 = FilledButton::declarer()
     .color(pipe!($btn1.color))
-    .finish(ctx);
+    .finish();
 
   btn1.write().color = Color::BLUE;
 }
@@ -142,7 +142,7 @@ use ribir::prelude::*;
 fn button_demo(ctx: &BuildCtx){
   let mut btn = FilledButton::declarer()
     .color(Color::RED)
-    .finish(ctx);
+    .finish();
 
   let m = btn.get_margin_widget().clone_writer();
   btn = btn.on_tap(move |_| m.write().margin = EdgeInsets::all(10.0));

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,6 +1,6 @@
 use ribir::prelude::*;
 
-pub fn counter(ctx: &mut BuildCtx) -> Widget<'static> {
+pub fn counter() -> Widget<'static> {
   let cnt = Stateful::new(0);
   let f = fn_widget! {
     @Row {
@@ -11,7 +11,7 @@ pub fn counter(ctx: &mut BuildCtx) -> Widget<'static> {
       @H1 { text: pipe!($cnt.to_string()) }
     }
   };
-  f(ctx)
+  f()
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]

--- a/examples/messages/src/messages.rs
+++ b/examples/messages/src/messages.rs
@@ -13,41 +13,40 @@ struct MessageList {
   messages: Vec<Message>,
 }
 
-pub fn messages(ctx: &mut BuildCtx) -> Widget<'static> {
-  let f = fn_widget! {
-    MessageList {
-      messages: vec![
-        Message {
-          nick_name: "James Harden".to_string(),
-          content: "Coming soon!".to_string(),
-          img:  Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-2.png"))),
-        },
-        Message {
-          nick_name: "Allen Iverson".to_string(),
-          content: "You are welcome!".to_string(),
-          img:  Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-1.png"))),
-        },
-        Message {
-          nick_name: "Kyrie Irving".to_string(),
-          content: "See you next week!".to_string(),
-          img:  Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-3.png"))),
-        },
-        Message {
-          nick_name: "Jaylon Lee".to_string(),
-          content: "Fighting!".to_string(),
-          img:  Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-4.png"))),
-        },
-      ],
-    }
-  };
-  f(ctx)
+pub fn messages() -> Widget<'static> {
+  MessageList {
+    messages: vec![
+      Message {
+        nick_name: "James Harden".to_string(),
+        content: "Coming soon!".to_string(),
+        img: Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-2.png"))),
+      },
+      Message {
+        nick_name: "Allen Iverson".to_string(),
+        content: "You are welcome!".to_string(),
+        img: Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-1.png"))),
+      },
+      Message {
+        nick_name: "Kyrie Irving".to_string(),
+        content: "See you next week!".to_string(),
+        img: Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-3.png"))),
+      },
+      Message {
+        nick_name: "Jaylon Lee".to_string(),
+        content: "Fighting!".to_string(),
+        img: Resource::new(PixelImage::from_png(include_bytes!("../../attachments/3DDD-4.png"))),
+      },
+    ],
+  }
+  .into_widget()
 }
 
 impl Compose for MessageList {
   fn compose(this: impl StateWriter<Value = Self>) -> Widget<'static> {
     fn_widget! {
+      let palette = Palette::of(BuildCtx::get());
       @Column {
-        background: Palette::of(ctx!()).surface(),
+        background: palette.surface(),
         @Row {
           justify_content: JustifyContent::SpaceBetween,
           padding: EdgeInsets::new(8., 16., 8., 16.),
@@ -57,8 +56,8 @@ impl Compose for MessageList {
             @TinyIcon { @{ svgs::MENU } }
             @Text {
               text: "Message",
-              foreground: Palette::of(ctx!()).on_surface(),
-              text_style: TypographyTheme::of(ctx!()).title_large.text.clone(),
+              foreground: palette.on_surface(),
+              text_style: TypographyTheme::of(BuildCtx::get()).title_large.text.clone(),
             }
           }
           @Row {

--- a/examples/storybook/src/storybook.rs
+++ b/examples/storybook/src/storybook.rs
@@ -33,10 +33,10 @@ fn content() -> Widget<'static> {
             @Column {
               item_gap: 20.,
               padding: EdgeInsets::new(20., 40., 20., 40.),
-              background: Palette::of(ctx!()).surface_container_low(),
+              background: Palette::of(BuildCtx::get()).surface_container_low(),
               border_radius: Radius::all(4.),
               border: Border::all(BorderSide {
-                color: Palette::of(ctx!()).primary().into(),
+                color: Palette::of(BuildCtx::get()).primary().into(),
                 width: 1.,
               }),
               @Row {
@@ -104,10 +104,10 @@ fn content() -> Widget<'static> {
             @Column {
               item_gap: 20.,
               padding: EdgeInsets::new(20., 40., 20., 40.),
-              background: Palette::of(ctx!()).surface_container_lowest(),
+              background: Palette::of(BuildCtx::get()).surface_container_lowest(),
               border_radius: Radius::all(4.),
               border: Border::all(BorderSide {
-                color: Palette::of(ctx!()).primary().into(),
+                color: Palette::of(BuildCtx::get()).primary().into(),
                 width: 1.,
               }),
               @Row {
@@ -137,10 +137,10 @@ fn content() -> Widget<'static> {
             @Column {
               item_gap: 20.,
               padding: EdgeInsets::new(20., 40., 20., 40.),
-              background: Palette::of(ctx!()).surface_container_lowest(),
+              background: Palette::of(BuildCtx::get()).surface_container_lowest(),
               border_radius: Radius::all(4.),
               border: Border::all(BorderSide {
-                color: Palette::of(ctx!()).primary().into(),
+                color: Palette::of(BuildCtx::get()).primary().into(),
                 width: 1.,
               }),
               @Row {
@@ -326,17 +326,17 @@ fn content() -> Widget<'static> {
   .into_widget()
 }
 
-pub fn storybook(ctx: &mut BuildCtx) -> Widget<'static> {
+pub fn storybook() -> Widget<'static> {
   let f = fn_widget! {
     @Column {
       clamp: BoxClamp::EXPAND_X,
       align_items: Align::Center,
-      background: Palette::of(ctx!()).surface_container_low(),
+      background: Palette::of(BuildCtx::get()).surface_container_low(),
       @ { header() }
       @Expanded {
         @ { content() }
       }
     }
   };
-  f(ctx)
+  f()
 }

--- a/examples/todos/src/ui.rs
+++ b/examples/todos/src/ui.rs
@@ -37,7 +37,10 @@ fn task_lists(
 ) -> GenWidget {
   fn_widget! {
     let editing = Stateful::new(None);
-    let stagger = Stagger::new(Duration::from_millis(100), transitions::EASE_IN_OUT.of(ctx!()));
+    let stagger = Stagger::new(
+      Duration::from_millis(100),
+      transitions::EASE_IN_OUT.of(BuildCtx::get())
+    );
     let c_stagger = stagger.clone_writer();
 
     @Scrollbar {
@@ -76,7 +79,6 @@ fn task_lists(
                         }
                       }
                     }.into_widget()
-
                   } else {
                     let _hint = || $stagger.write();
                     let item = task_item_widget(task.clone_writer(), stagger.clone_writer());
@@ -110,7 +112,7 @@ fn input(
       margin: EdgeInsets::horizontal(24.),
       h_align: HAlign::Stretch,
       border: {
-        let color = Palette::of(ctx!()).surface_variant().into();
+        let color = Palette::of(BuildCtx::get()).surface_variant().into();
         Border::only_bottom(BorderSide { width: 2., color })
       },
       on_key_down: move |e| {
@@ -146,7 +148,6 @@ where
       let fly_in = stagger.push_state(
         (transform, opacity),
         (Transform::translation(0., 64.), 0.),
-        ctx!()
       );
       // items not displayed until the stagger animation is started.
       watch!($fly_in.is_running()).filter(|v| *v).first().subscribe(move |_| {
@@ -176,7 +177,7 @@ where
   .into_widget()
 }
 
-pub fn todos(_: &mut BuildCtx) -> Widget<'static> {
+pub fn todos() -> Widget<'static> {
   let todos = if cfg!(not(target_arch = "wasm32")) {
     let todos = State::value(Todos::load());
     // save changes to disk every 5 seconds .

--- a/examples/wordle_game/src/ui.rs
+++ b/examples/wordle_game/src/ui.rs
@@ -18,7 +18,7 @@ trait WordleExtraWidgets: StateWriter<Value = Wordle> + Sized + 'static {
     fn_widget! {
       @FilledButton {
         on_tap: move |_| $this.write().guessing.enter_char(key),
-        color: pipe!{ hint_color($this.key_hint(key), ctx!()) },
+        color: pipe!{ hint_color($this.key_hint(key)) },
         @ { Label::new(key.to_string()) }
       }
     }
@@ -99,8 +99,8 @@ trait WordleExtraWidgets: StateWriter<Value = Wordle> + Sized + 'static {
 
 impl<T: StateWriter<Value = Wordle> + 'static> WordleExtraWidgets for T {}
 
-fn hint_color(hint: Option<CharHint>, ctx: &BuildCtx) -> Color {
-  let palette = Palette::of(ctx);
+fn hint_color(hint: Option<CharHint>) -> Color {
+  let palette = Palette::of(BuildCtx::get());
   hint.map_or_else(
     || palette.surface_variant(),
     |s| match s {
@@ -129,7 +129,7 @@ impl Wordle {
     let hint = char_hint.and_then(|c| c.hint);
 
     fn_widget! {
-      let color = hint_color(hint, ctx!());
+      let color = hint_color(hint);
       let palette = Palette::of(ctx!());
 
       let color = palette.container_of(&color);

--- a/examples/wordle_game/src/ui.rs
+++ b/examples/wordle_game/src/ui.rs
@@ -2,7 +2,7 @@ use ribir::prelude::*;
 
 use crate::wordle::{CharHint, Wordle, WordleChar};
 
-pub fn wordle_game(_: &mut BuildCtx) -> Widget<'static> { Wordle::new(5, 5).into_widget() }
+pub fn wordle_game() -> Widget<'static> { Wordle::new(5, 5).into_widget() }
 
 trait WordleExtraWidgets: StateWriter<Value = Wordle> + Sized + 'static {
   fn chars_key<const N: usize>(
@@ -28,7 +28,7 @@ trait WordleExtraWidgets: StateWriter<Value = Wordle> + Sized + 'static {
   fn keyboard(self, state_bar: impl StateWriter<Value = Text> + 'static) -> Widget<'static> {
     let this: <Self as StateWriter>::Writer = self.clone_writer();
     fn_widget! {
-    let palette = Palette::of(ctx!());
+    let palette = Palette::of(BuildCtx::get());
     @Column {
         item_gap: 5.,
         align_items: Align::Center,
@@ -130,7 +130,7 @@ impl Wordle {
 
     fn_widget! {
       let color = hint_color(hint);
-      let palette = Palette::of(ctx!());
+      let palette = Palette::of(BuildCtx::get());
 
       let color = palette.container_of(&color);
       let font_color = palette.on_container_of(&color);
@@ -139,7 +139,7 @@ impl Wordle {
         background: color,
         border_radius: Radius::all(4.),
         @Text {
-          text_style: TypographyTheme::of(ctx!()).display_small.text.clone(),
+          text_style: TypographyTheme::of(BuildCtx::get()).display_small.text.clone(),
           foreground: font_color,
           h_align: HAlign::Center,
           v_align: VAlign::Center,

--- a/macros/src/child_template.rs
+++ b/macros/src/child_template.rs
@@ -97,7 +97,7 @@ pub(crate) fn derive_child_template(input: &mut syn::DeriveInput) -> syn::Result
         impl #g_impl ObjDeclarer for #builder #g_ty {
           type Target = Self;
           #[inline]
-          fn finish(self, _: &BuildCtx) -> Self { self }
+          fn finish(self) -> Self { self }
         }
       });
 

--- a/macros/src/declare_derive.rs
+++ b/macros/src/declare_derive.rs
@@ -57,7 +57,7 @@ pub(crate) fn declare_derive(input: &mut syn::DeriveInput) -> syn::Result<TokenS
         type Target = FatObj<State<#host #g_ty>>;
 
         #[inline]
-        fn finish(mut self, ctx!(): &BuildCtx) -> Self::Target {
+        fn finish(mut self) -> Self::Target {
           #(#field_values)*
           let mut _this_ಠ_ಠ = State::value(#host {
             #(#field_names : #field_names.0),*

--- a/macros/src/declare_obj.rs
+++ b/macros/src/declare_obj.rs
@@ -136,12 +136,7 @@ impl DeclareObj {
     match &self.this.node_type {
       ObjType::Type { ty, span } => {
         let name = Ident::new("_ಠ_ಠ", *span);
-        self.gen_fields_tokens(
-          &name,
-          quote! { #ty::declarer() },
-          quote! { .finish() },
-          tokens,
-        );
+        self.gen_fields_tokens(&name, quote! { #ty::declarer() }, quote! { .finish() }, tokens);
       }
       ObjType::Var { var, used_me } => {
         // if has capture self, rename to `_ಠ_ಠ` avoid conflict name.

--- a/macros/src/declare_obj.rs
+++ b/macros/src/declare_obj.rs
@@ -139,7 +139,7 @@ impl DeclareObj {
         self.gen_fields_tokens(
           &name,
           quote! { #ty::declarer() },
-          quote! { .finish(ctx!()) },
+          quote! { .finish() },
           tokens,
         );
       }
@@ -184,7 +184,7 @@ impl DeclareObj {
     //
     // ```
     // let mut x = ...;
-    // X::declarer().a(&mut x.a).b(&mut x.b).finish(ctx!());
+    // X::declarer().a(&mut x.a).b(&mut x.b).finish();
     // ```
     //
     // In this scenario, `x` would be borrowed twice, causing a compilation failure

--- a/macros/src/fn_widget_macro.rs
+++ b/macros/src/fn_widget_macro.rs
@@ -18,7 +18,6 @@ pub(crate) fn gen_code(input: TokenStream, refs_ctx: &mut DollarRefsCtx) -> Toke
       .map(|s| refs_ctx.fold_stmt(s))
       .collect();
 
-    refs_ctx.current_dollar_scope_mut().used_ctx = false;
     let _ = refs_ctx.pop_dollar_scope(false);
     Ok(quote! {
       move |ctx!(): &mut BuildCtx| -> Widget { #(#stmts)*.into_widget() }

--- a/macros/src/fn_widget_macro.rs
+++ b/macros/src/fn_widget_macro.rs
@@ -20,7 +20,7 @@ pub(crate) fn gen_code(input: TokenStream, refs_ctx: &mut DollarRefsCtx) -> Toke
 
     let _ = refs_ctx.pop_dollar_scope(false);
     Ok(quote! {
-      move |ctx!(): &mut BuildCtx| -> Widget { #(#stmts)*.into_widget() }
+      move || -> Widget { #(#stmts)*.into_widget() }
     })
   });
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -140,18 +140,6 @@ pub fn fn_widget(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn ribir_expanded_ಠ_ಠ(input: TokenStream) -> TokenStream { input }
 
-/// The `ctx!` macro is a special name that use to share the `BuildCtx` between
-/// macros.
-#[proc_macro]
-pub fn ctx(input: TokenStream) -> TokenStream {
-  let tokens = if !input.is_empty() {
-    quote!(compile_error!("ctx! macro does not accept any argument"))
-  } else {
-    quote! { _ctx_ಠ_ಠ }
-  };
-  tokens.into()
-}
-
 /// This macro is utilized for generating a `Pipe` object that actively monitors
 /// the expression's result.
 ///

--- a/macros/src/simple_declare_attr.rs
+++ b/macros/src/simple_declare_attr.rs
@@ -42,7 +42,7 @@ pub(crate) fn simple_declarer_attr(stt: &mut syn::ItemStruct) -> Result<TokenStr
       type Target = State<#ident #g_ty>;
 
       #[inline]
-      fn finish(mut self, ctx!(): &BuildCtx) -> Self::Target {
+      fn finish(mut self) -> Self::Target {
         State::value(#ident {#(#init_pairs),*})
       }
     }
@@ -74,7 +74,7 @@ fn empty_impl(stt: &syn::ItemStruct) -> Result<TokenStream> {
     impl ObjDeclarer for #name {
       type Target = #name;
       #[inline]
-      fn finish(self, _: &BuildCtx) -> Self::Target { self }
+      fn finish(self) -> Self::Target { self }
     }
   };
   Ok(tokens)

--- a/macros/src/watch_macro.rs
+++ b/macros/src/watch_macro.rs
@@ -29,17 +29,7 @@ pub fn process_watch_body(
     .map(|s| refs_ctx.fold_stmt(s))
     .collect::<Vec<_>>();
   let refs = refs_ctx.pop_dollar_scope(true);
-  let map_handler = if refs.used_ctx() {
-    quote! {
-      let _ctx_handle_ಠ_ಠ = ctx!().handle();
-      move |_: ModifyScope| _ctx_handle_ಠ_ಠ
-        .with_ctx(|ctx!(): &mut BuildCtx| { #(#expr)* })
-        .expect("ctx is not available")
-    }
-  } else {
-    quote! { move |_: ModifyScope| { #(#expr)* } }
-  };
-
+  let map_handler = quote! { move |_: ModifyScope| { #(#expr)* } };
   if refs.is_empty() {
     Err(Error::WatchNothing(span))
   } else {

--- a/tests/declare_builder_test.rs
+++ b/tests/declare_builder_test.rs
@@ -1,14 +1,12 @@
 use ribir::prelude::*;
 
-fn dummy_ctx() -> &'static BuildCtx { unsafe { std::mem::transmute(&0) } }
-
 #[test]
 fn declarer_smoke() {
   // empty struct
   #[derive(Declare)]
   struct A;
 
-  let _: FatObj<A> = A::declarer().finish(dummy_ctx());
+  let _: FatObj<A> = A::declarer().finish();
 
   #[derive(Declare)]
   struct B {
@@ -16,10 +14,7 @@ fn declarer_smoke() {
     b: i32,
   }
 
-  let b = <B as Declare>::declarer()
-    .a(1.)
-    .b(1)
-    .finish(dummy_ctx());
+  let b = <B as Declare>::declarer().a(1.).b(1).finish();
   assert_eq!(b.read().a, 1.);
   assert_eq!(b.read().b, 1);
 }
@@ -32,7 +27,7 @@ fn panic_if_miss_require_field() {
     _a: f32,
   }
 
-  let _ = <T as Declare>::declarer().finish(dummy_ctx());
+  let _ = <T as Declare>::declarer().finish();
 }
 
 #[test]
@@ -44,7 +39,7 @@ fn default_field() {
     a: f32,
   }
 
-  let t = <DefaultDeclare as Declare>::declarer().finish(dummy_ctx());
+  let t = <DefaultDeclare as Declare>::declarer().finish();
   assert_eq!(t.read().a, 0.);
 }
 
@@ -57,7 +52,7 @@ fn default_field_with_value() {
     text: &'static str,
   }
 
-  let t = <DefaultWithValue as Declare>::declarer().finish(dummy_ctx());
+  let t = <DefaultWithValue as Declare>::declarer().finish();
   assert_eq!(t.read().text, "hi!");
 }
 
@@ -69,7 +64,7 @@ fn declarer_simple_attr() {
     b: i32,
   }
 
-  let s = Simple::declarer().a(1.).b(1).finish(dummy_ctx());
+  let s = Simple::declarer().a(1.).b(1).finish();
   assert_eq!(s.read().a, 1.);
   assert_eq!(s.read().b, 1);
 }

--- a/tests/rdl_macro_test.rs
+++ b/tests/rdl_macro_test.rs
@@ -166,7 +166,7 @@ widget_layout_test!(
     let (scale, w_scale) = split_value(1.);
     let w = fn_widget! {
       rdl!{ SizedBox {
-        size: pipe!(IconSize::of(ctx!()).tiny * *$scale)
+        size: pipe!(IconSize::of(BuildCtx::get()).tiny * *$scale)
       }}
     };
     *w_scale.write() = 2.;
@@ -193,7 +193,7 @@ widget_layout_test!(
   WidgetTester::new(fn_widget! {
     let size_box = @SizedBox { size: ZERO_SIZE };
     @ $size_box {
-      on_mounted: move |_| $size_box.write().size = IconSize::of(ctx!()).tiny
+      on_mounted: move |e| $size_box.write().size = IconSize::of(&e).tiny
     }
   }),
   LayoutCase::default().with_size(Size::new(18., 18.))

--- a/tests/rdl_macro_test.rs
+++ b/tests/rdl_macro_test.rs
@@ -833,7 +833,7 @@ fn no_watch() {
 
 #[test]
 fn fix_direct_use_map_writer_with_builtin() {
-  fn _x(mut host: FatObj<Void>, ctx!(): &BuildCtx) {
+  fn _x(mut host: FatObj<Void>) {
     let _anchor = host
       .get_relative_anchor_widget()
       .map_writer(|w| PartData::from_ref_mut(&mut w.anchor));

--- a/themes/material/src/classes/radio_cls.rs
+++ b/themes/material/src/classes/radio_cls.rs
@@ -11,9 +11,10 @@ const BORDER_SIZE: f32 = 2.;
 pub(super) fn init(classes: &mut Classes) {
   classes.insert(RADIO_SELECTED, |_w| {
     fn_widget! {
+      let ctx = BuildCtx::get();
       @InteractiveLayer {
         border_radii: Radius::all(TOTAL_SIZE / 2.),
-        color: Palette::of(ctx!()).primary(),
+        color: Palette::of(ctx).primary(),
         @Container {
           size: Size::new(TOTAL_SIZE, TOTAL_SIZE),
           cursor: CursorIcon::Pointer,
@@ -23,14 +24,14 @@ pub(super) fn init(classes: &mut Classes) {
             size: Size::new(CONTAINER_SIZE, CONTAINER_SIZE),
             border_radius: Radius::all(CONTAINER_SIZE / 2.),
             border: Border::all(
-              BorderSide::new(BORDER_SIZE, Palette::of(ctx!()).primary().into())
+              BorderSide::new(BORDER_SIZE, Palette::of(ctx).primary().into())
             ),
             @Container {
               v_align: VAlign::Center,
               h_align: HAlign::Center,
               size: Size::new(INDICATOR_SIZE, INDICATOR_SIZE),
               border_radius: Radius::all(INDICATOR_SIZE / 2.),
-              background: Palette::of(ctx!()).primary(),
+              background: Palette::of(ctx).primary(),
             }
           }
         }
@@ -41,9 +42,10 @@ pub(super) fn init(classes: &mut Classes) {
 
   classes.insert(RADIO_UNSELECTED, |_w| {
     fn_widget! {
+      let ctx = BuildCtx::get();
       @InteractiveLayer {
         border_radii: Radius::all(TOTAL_SIZE / 2.),
-        color: Palette::of(ctx!()).primary(),
+        color: Palette::of(ctx).primary(),
         @Container {
           cursor: CursorIcon::Pointer,
           size: Size::new(TOTAL_SIZE, TOTAL_SIZE),
@@ -53,7 +55,7 @@ pub(super) fn init(classes: &mut Classes) {
             size: Size::new(CONTAINER_SIZE, CONTAINER_SIZE),
             border_radius: Radius::all(CONTAINER_SIZE / 2.),
             border: Border::all(
-              BorderSide::new(BORDER_SIZE, Palette::of(ctx!()).on_surface_variant().into())
+              BorderSide::new(BORDER_SIZE, Palette::of(ctx).on_surface_variant().into())
             ),
           }
         }

--- a/themes/material/src/classes/scrollbar_cls.rs
+++ b/themes/material/src/classes/scrollbar_cls.rs
@@ -17,13 +17,13 @@ pub(super) fn init(classes: &mut Classes) {
   classes.insert(SCROLL_CLIENT_AREA, |w| w);
 
   classes.insert(H_SCROLL_THUMB, style_class! {
-    background: Palette::of(ctx!()).primary(),
+    background: Palette::of(BuildCtx::get()).primary(),
     border_radius: RADIUS,
     margin: EdgeInsets::vertical(1.),
     clamp: BoxClamp::min_width(THUMB_MIN_SIZE).with_fixed_height(THICKNESS)
   });
   classes.insert(V_SCROLL_THUMB, style_class! {
-    background: Palette::of(ctx!()).primary(),
+    background: Palette::of(BuildCtx::get()).primary(),
     border_radius: RADIUS,
     margin: EdgeInsets::horizontal(1.),
     clamp: BoxClamp::min_height(THUMB_MIN_SIZE).with_fixed_width(THICKNESS)
@@ -42,7 +42,7 @@ pub(super) fn init(classes: &mut Classes) {
 
 fn base_track(w: Widget) -> Widget {
   fn_widget! {
-    let scroll = &*Provider::of::<Stateful<ScrollableWidget>>(ctx!()).unwrap();
+    let scroll = &*Provider::of::<Stateful<ScrollableWidget>>(BuildCtx::get()).unwrap();
     let mut w = FatObj::new(w).opacity(0.);
 
     // Show the scrollbar when scrolling.
@@ -69,7 +69,7 @@ fn base_track(w: Widget) -> Widget {
 
     let mut w = @ $w {
       background: {
-        let color = Palette::of(ctx!()).primary_container();
+        let color = Palette::of(BuildCtx::get()).primary_container();
         pipe!(if $w.is_hover() { color } else { color.with_alpha(0.)})
       },
       on_disposed: move |_| u.unsubscribe(),

--- a/themes/material/src/classes/scrollbar_cls.rs
+++ b/themes/material/src/classes/scrollbar_cls.rs
@@ -65,9 +65,7 @@ fn base_track(w: Widget) -> Widget {
       duration: md::easing::duration::MEDIUM2
     };
     // Smoothly fade in and out the scrollbar.
-    w.get_opacity_widget()
-      .map_writer(|w|  PartData::from_ref_mut(&mut w.opacity))
-      .transition(trans.clone(), ctx!());
+    part_writer!(&mut w.opacity).transition(trans.clone());
 
     let mut w = @ $w {
       background: {
@@ -77,9 +75,7 @@ fn base_track(w: Widget) -> Widget {
       on_disposed: move |_| u.unsubscribe(),
     };
     // Smoothly display the background.
-    w.get_box_decoration_widget()
-      .map_writer(|w|  PartData::from_ref_mut(&mut w.background))
-      .transition(trans, ctx!());
+    part_writer!(&mut w.background).transition(trans);
 
     w
   }

--- a/themes/material/src/lib.rs
+++ b/themes/material/src/lib.rs
@@ -251,7 +251,7 @@ fn override_compose_decorator(theme: &mut Theme) {
       };
 
       part_writer!(&mut indicator.anchor)
-        .transition(transitions::EASE_IN.of(ctx!()));
+        .transition(transitions::EASE_IN.of(BuildCtx::get()));
       indicator
     }
     .into_widget()
@@ -279,14 +279,14 @@ fn override_compose_decorator(theme: &mut Theme) {
       @Ripple {
         center: false,
         color: {
-          let palette = Palette::of(ctx!()).clone();
+          let palette = Palette::of(BuildCtx::get()).clone();
           pipe!(palette.on_of(&palette.base_of(&$style.color)))
         },
         bounded: RippleBound::Radius(Radius::all(20.)),
         @InteractiveLayer {
           border_radii: Radius::all(20.),
           color: {
-            let palette = Palette::of(ctx!()).clone();
+            let palette = Palette::of(BuildCtx::get()).clone();
             pipe!(palette.on_of(&palette.base_of(&$style.color)))
           },
           @$host {
@@ -303,14 +303,14 @@ fn override_compose_decorator(theme: &mut Theme) {
       @Ripple {
         center: false,
         color: {
-          let palette = Palette::of(ctx!()).clone();
+          let palette = Palette::of(BuildCtx::get()).clone();
           pipe!(palette.base_of(&$style.color))
         },
         bounded: RippleBound::Radius(Radius::all(20.)),
         @InteractiveLayer {
           border_radii: Radius::all(20.),
           color: {
-            let palette = Palette::of(ctx!()).clone();
+            let palette = Palette::of(BuildCtx::get()).clone();
             pipe!(palette.base_of(&$style.color))
           },
           @ $host {
@@ -327,14 +327,14 @@ fn override_compose_decorator(theme: &mut Theme) {
       @Ripple {
         center: false,
         color: {
-          let palette = Palette::of(ctx!()).clone();
+          let palette = Palette::of(BuildCtx::get()).clone();
           pipe!(palette.on_of(&palette.base_of(&$style.color)))
         },
         bounded: RippleBound::Radius(Radius::all(20.)),
         @InteractiveLayer {
           border_radii: Radius::all(20.),
           color: {
-            let palette = Palette::of(ctx!()).clone();
+            let palette = Palette::of(BuildCtx::get()).clone();
             pipe!(palette.on_of(&palette.base_of(&$style.color)))
           },
           @ $host {

--- a/themes/material/src/lib.rs
+++ b/themes/material/src/lib.rs
@@ -250,10 +250,8 @@ fn override_compose_decorator(theme: &mut Theme) {
         },
       };
 
-      indicator
-        .get_relative_anchor_widget()
-        .map_writer(|w| PartData::from_ref_mut(&mut w.anchor))
-        .transition(transitions::EASE_IN.of(ctx!()), ctx!());
+      part_writer!(&mut indicator.anchor)
+        .transition(transitions::EASE_IN.of(ctx!()));
       indicator
     }
     .into_widget()

--- a/themes/material/src/ripple.rs
+++ b/themes/material/src/ripple.rs
@@ -60,7 +60,7 @@ impl<'c> ComposeChild<'c> for Ripple {
           };
 
           let ripper_enter = @Animate {
-            transition: transitions::LINEAR.of(ctx!()),
+            transition: transitions::LINEAR.of(BuildCtx::get()),
             state: LerpFnState::new(
               ripple.map_writer(|w| PartData::from_ref_mut(&mut w.path)),
               move |_, _, rate| {
@@ -82,7 +82,7 @@ impl<'c> ComposeChild<'c> for Ripple {
           let ripper_fade_out = ripple
             .get_opacity_widget()
             .map_writer(|w| PartData::from_ref_mut(&mut w.opacity))
-            .transition(transitions::EASE_OUT.of(ctx!()));
+            .transition(transitions::EASE_OUT.of(BuildCtx::get()));
 
           let bounded = $this.bounded;
           let clipper = (bounded != RippleBound::Unbounded).then(|| {

--- a/themes/material/src/ripple.rs
+++ b/themes/material/src/ripple.rs
@@ -82,7 +82,7 @@ impl<'c> ComposeChild<'c> for Ripple {
           let ripper_fade_out = ripple
             .get_opacity_widget()
             .map_writer(|w| PartData::from_ref_mut(&mut w.opacity))
-            .transition(transitions::EASE_OUT.of(ctx!()), ctx!());
+            .transition(transitions::EASE_OUT.of(ctx!()));
 
           let bounded = $this.bounded;
           let clipper = (bounded != RippleBound::Unbounded).then(|| {

--- a/widgets/src/avatar.rs
+++ b/widgets/src/avatar.rs
@@ -25,7 +25,7 @@ use crate::prelude::*;
 /// ```
 #[derive(Declare, Default, Clone)]
 pub struct Avatar {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   pub color: Color,
 }
 

--- a/widgets/src/avatar.rs
+++ b/widgets/src/avatar.rs
@@ -63,51 +63,48 @@ impl ComposeChild<'static> for Avatar {
 
   fn compose_child(this: impl StateWriter<Value = Self>, child: Self::Child) -> Widget<'static> {
     fn_widget! {
-      @ {
-        let AvatarStyle {
-          size, radius, text_style,
-        } = AvatarStyle::of(ctx!());
-        let palette1 = Palette::of(ctx!()).clone();
-        let palette2 = Palette::of(ctx!()).clone();
-        let w: Widget = match child {
-          AvatarTemplate::Text(text) => {
+      let ctx = BuildCtx::get();
+      let AvatarStyle { size, radius, text_style } = AvatarStyle::of(ctx);
+      let palette1 = Palette::of(ctx).clone();
+      let palette2 = Palette::of(ctx).clone();
+      let w: Widget = match child {
+        AvatarTemplate::Text(text) => {
+          @Container {
+            size,
+            border_radius: radius.map(Radius::all),
+            background: pipe!(Brush::from(palette1.base_of(&$this.color))),
+            @Text {
+              h_align: HAlign::Center,
+              v_align: VAlign::Center,
+              text: text.0,
+              text_style,
+              foreground: pipe!(Brush::from(palette2.on_of(&palette2.base_of(&$this.color)))),
+            }
+          }.into_widget()
+        },
+        AvatarTemplate::Image(image) => {
+          let image = FatObj::new(image);
+          let clip = radius.map(|radius| {
+            let path = Path::rect_round(
+              &Rect::from_size(size),
+              &Radius::all(radius),
+            );
+            Clip { clip: ClipType::Path(path) }
+          });
+          @$clip {
             @Container {
               size,
-              border_radius: radius.map(Radius::all),
-              background: pipe!(Brush::from(palette1.base_of(&$this.color))),
-              @Text {
-                h_align: HAlign::Center,
-                v_align: VAlign::Center,
-                text: text.0,
-                text_style,
-                foreground: pipe!(Brush::from(palette2.on_of(&palette2.base_of(&$this.color)))),
-              }
-            }.into_widget()
-          },
-          AvatarTemplate::Image(image) => {
-            let image = FatObj::new(image);
-            let clip = radius.map(|radius| {
-              let path = Path::rect_round(
-                &Rect::from_size(size),
-                &Radius::all(radius),
-              );
-              Clip { clip: ClipType::Path(path) }
-            });
-            @$clip {
-              @Container {
-                size,
-                @$image {
-                  box_fit: BoxFit::Contain,
-                }
+              @$image {
+                box_fit: BoxFit::Contain,
               }
             }
           }
-        };
-
-        @SizedBox {
-          size,
-          @ { w }
         }
+      };
+
+      @SizedBox {
+        size,
+        @ { w }
       }
     }
     .into_widget()

--- a/widgets/src/buttons/button.rs
+++ b/widgets/src/buttons/button.rs
@@ -63,7 +63,7 @@ impl ComposeDecorator for ButtonDecorator {
 /// ```
 #[derive(Default, Declare)]
 pub struct Button {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   color: Color,
 }
 

--- a/widgets/src/buttons/button.rs
+++ b/widgets/src/buttons/button.rs
@@ -80,6 +80,7 @@ impl ComposeChild<'static> for Button {
     };
 
     fn_widget! {
+      let ctx = BuildCtx::get();
       @ {
         let ButtonStyle {
           height,
@@ -88,8 +89,8 @@ impl ComposeChild<'static> for Button {
           icon_pos,
           label_style,
           padding_style,
-        } = ButtonStyle::of(ctx!());
-        let palette = Palette::of(ctx!()).clone();
+        } = ButtonStyle::of(ctx);
+        let palette = Palette::of(ctx).clone();
 
         @ButtonDecorator {
           button_type,

--- a/widgets/src/buttons/fab_button.rs
+++ b/widgets/src/buttons/fab_button.rs
@@ -92,6 +92,7 @@ impl ComposeChild<'static> for FabButton {
 
     fn_widget! {
       @ {
+        let ctx = BuildCtx::get();
         let FabButtonStyle {
           height,
           icon_size,
@@ -100,9 +101,9 @@ impl ComposeChild<'static> for FabButton {
           label_style,
           radius,
           padding_style,
-        } = FabButtonStyle::of(ctx!());
-        let palette1 = Palette::of(ctx!()).clone();
-        let palette2 = Palette::of(ctx!()).clone();
+        } = FabButtonStyle::of(ctx);
+        let palette1 = Palette::of(ctx).clone();
+        let palette2 = Palette::of(ctx).clone();
 
         @FabButtonDecorator {
           button_type,

--- a/widgets/src/buttons/fab_button.rs
+++ b/widgets/src/buttons/fab_button.rs
@@ -74,7 +74,7 @@ impl ComposeDecorator for FabButtonDecorator {
 /// ```
 #[derive(Default, Declare)]
 pub struct FabButton {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   color: Color,
 }
 

--- a/widgets/src/buttons/filled_button.rs
+++ b/widgets/src/buttons/filled_button.rs
@@ -111,9 +111,9 @@ impl ComposeChild<'static> for FilledButton {
             label_gap,
             icon_pos,
             label_style,
-            background_color: pipe!(Palette::of(ctx!()).base_of(&$this.color)),
+            background_color: pipe!(Palette::of(BuildCtx::get()).base_of(&$this.color)),
             foreground_color: pipe! {
-              let palette = Palette::of(ctx!());
+              let palette = Palette::of(BuildCtx::get());
               palette.on_of(&palette.base_of(&$this.color))
             },
             radius,

--- a/widgets/src/buttons/filled_button.rs
+++ b/widgets/src/buttons/filled_button.rs
@@ -92,6 +92,7 @@ impl ComposeChild<'static> for FilledButton {
 
     fn_widget! {
       @ {
+        let ctx = BuildCtx::get();
         let FilledButtonStyle {
           height,
           icon_size,
@@ -100,7 +101,7 @@ impl ComposeChild<'static> for FilledButton {
           label_style,
           radius,
           padding_style,
-        } = FilledButtonStyle::of(ctx!());
+        } = FilledButtonStyle::of(ctx);
 
         @FilledButtonDecorator {
           button_type,

--- a/widgets/src/buttons/filled_button.rs
+++ b/widgets/src/buttons/filled_button.rs
@@ -74,7 +74,7 @@ impl ComposeDecorator for FilledButtonDecorator {
 /// ```
 #[derive(Declare, Default)]
 pub struct FilledButton {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   pub color: Color,
 }
 

--- a/widgets/src/buttons/outlined_button.rs
+++ b/widgets/src/buttons/outlined_button.rs
@@ -76,7 +76,7 @@ impl ComposeDecorator for OutlinedButtonDecorator {
 /// ```
 #[derive(Default, Declare)]
 pub struct OutlinedButton {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   color: Color,
 }
 

--- a/widgets/src/buttons/outlined_button.rs
+++ b/widgets/src/buttons/outlined_button.rs
@@ -103,7 +103,7 @@ impl ComposeChild<'static> for OutlinedButton {
           radius,
           padding_style,
           border_width,
-        } = OutlinedButtonStyle::of(ctx!());
+        } = OutlinedButtonStyle::of(BuildCtx::get());
 
         @OutlinedButtonDecorator {
           button_type,

--- a/widgets/src/buttons/outlined_button.rs
+++ b/widgets/src/buttons/outlined_button.rs
@@ -115,11 +115,11 @@ impl ComposeChild<'static> for OutlinedButton {
             icon_pos,
             label_style,
             background_color: None,
-            foreground_color: pipe!(Palette::of(ctx!()).base_of(&$this.color)),
+            foreground_color: pipe!(Palette::of(BuildCtx::get()).base_of(&$this.color)),
             radius,
             border_style: pipe!(Border::all(BorderSide {
               width: border_width,
-              color: Palette::of(ctx!()).base_of(&$this.color).into()
+              color: Palette::of(BuildCtx::get()).base_of(&$this.color).into()
             })),
             padding_style,
 

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -12,7 +12,7 @@ pub struct Checkbox {
   pub checked: bool,
   #[declare(default)]
   pub indeterminate: bool,
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get() ).primary())]
   pub color: Color,
 }
 
@@ -28,7 +28,7 @@ pub struct CheckBoxStyle {
 
 #[derive(Clone, Declare)]
 pub struct CheckBoxDecorator {
-  #[declare(default=Palette::of(ctx!()).primary())]
+  #[declare(default=Palette::of(BuildCtx::get()).primary())]
   pub color: Color,
 }
 

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -62,7 +62,7 @@ impl ComposeChild<'static> for Checkbox {
         icon_size,
         label_style,
         label_color,
-      } = CheckBoxStyle::of(ctx!());
+      } = CheckBoxStyle::of(BuildCtx::get());
 
       let icon = @CheckBoxDecorator {
         color: pipe!($this.color),

--- a/widgets/src/divider.rs
+++ b/widgets/src/divider.rs
@@ -43,7 +43,7 @@ pub struct Divider {
   // Extent of divider
   pub extent: f32,
   // Color of divider
-  #[declare(default=Palette::of(ctx!()).outline_variant())]
+  #[declare(default=Palette::of(BuildCtx::get()).outline_variant())]
   pub color: Brush,
   // Direction of divider
   #[declare(default=Direction::Horizontal)]

--- a/widgets/src/icon.rs
+++ b/widgets/src/icon.rs
@@ -44,7 +44,7 @@ macro_rules! define_fixed_size_icon {
           -> Widget<'c>
         {
           fn_widget! {
-            let icon = @Icon { size: IconSize::of(ctx!()).$field };
+            let icon = @Icon { size: IconSize::of(BuildCtx::get()).$field };
             @ $icon { @ { child } }
           }.into_widget()
         }

--- a/widgets/src/icon.rs
+++ b/widgets/src/icon.rs
@@ -10,7 +10,7 @@ use crate::layout::SizedBox;
 /// a icon.
 #[derive(Declare, Default, Clone, Copy)]
 pub struct Icon {
-  #[declare(default = IconSize::of(ctx!()).small)]
+  #[declare(default = IconSize::of(BuildCtx::get()).small)]
   pub size: Size,
 }
 

--- a/widgets/src/input.rs
+++ b/widgets/src/input.rs
@@ -362,7 +362,8 @@ where
         ),
       };
       let scrollable = stack.get_scrollable_widget();
-      let tick_of_layout_ready = ctx!().window()
+      let wnd = BuildCtx::get().window();
+      let tick_of_layout_ready = wnd
         .frame_tick_stream()
         .filter(|msg| matches!(msg, FrameMsg::LayoutReady(_)));
       watch!(SelectableText::caret(&*$this))
@@ -384,7 +385,7 @@ where
       };
 
       let ime_handle = Stateful::new(
-        ImeHandle::new(ctx!().window(), this.clone_writer(), caret_box_id)
+        ImeHandle::new(wnd, this.clone_writer(), caret_box_id)
       );
       let mut stack = @ $stack {
         on_focus: move |_| $ime_handle.write().ime_allowed(),

--- a/widgets/src/input.rs
+++ b/widgets/src/input.rs
@@ -79,19 +79,19 @@ pub trait EditableText: Sized {
 
 #[derive(Declare)]
 pub struct Input {
-  #[declare(default = TypographyTheme::of(ctx!()).body_large.text.clone())]
+  #[declare(default = TypographyTheme::of(BuildCtx::get()).body_large.text.clone())]
   pub style: TextStyle,
   #[declare(skip)]
   text: CowArc<str>,
   #[declare(skip)]
   caret: CaretState,
-  #[declare(default = InputStyle::of(ctx!()).size)]
+  #[declare(default = InputStyle::of(BuildCtx::get()).size)]
   size: Option<f32>,
 }
 
 #[derive(Declare)]
 pub struct TextArea {
-  #[declare(default = TypographyTheme::of(ctx!()).body_large.text.clone())]
+  #[declare(default = TypographyTheme::of(BuildCtx::get()).body_large.text.clone())]
   pub style: TextStyle,
   #[declare(default = true)]
   pub auto_wrap: bool,
@@ -99,9 +99,9 @@ pub struct TextArea {
   text: CowArc<str>,
   #[declare(skip)]
   caret: CaretState,
-  #[declare(default = TextAreaStyle::of(ctx!()).rows)]
+  #[declare(default = TextAreaStyle::of(BuildCtx::get()).rows)]
   rows: Option<f32>,
-  #[declare(default = TextAreaStyle::of(ctx!()).cols)]
+  #[declare(default = TextAreaStyle::of(BuildCtx::get()).cols)]
   cols: Option<f32>,
 }
 

--- a/widgets/src/input/selected_text.rs
+++ b/widgets/src/input/selected_text.rs
@@ -20,7 +20,7 @@ impl CustomStyle for SelectedHighLightStyle {
 impl Compose for SelectedHighLight {
   fn compose(this: impl StateWriter<Value = Self>) -> Widget<'static> {
     fn_widget! {
-      let color = SelectedHighLightStyle::of(ctx!()).brush;
+      let color = SelectedHighLightStyle::of(BuildCtx::get()).brush;
       @Stack {
         @ { pipe!{
           let color = color.clone();

--- a/widgets/src/lists.rs
+++ b/widgets/src/lists.rs
@@ -322,7 +322,7 @@ impl<'c> ComposeChild<'c> for ListItem {
 pub struct ListItem {
   #[declare(default = 1usize)]
   pub line_number: usize,
-  #[declare(default = Palette::of(ctx!()).primary())]
+  #[declare(default = Palette::of(BuildCtx::get()).primary())]
   pub active_background: Color,
 }
 

--- a/widgets/src/lists.rs
+++ b/widgets/src/lists.rs
@@ -261,6 +261,7 @@ impl<'c> ComposeChild<'c> for ListItem {
     let ListItemTml { headline, supporting, leading, trailing } = child;
 
     fn_widget! {
+      let ctx = BuildCtx::get();
       let ListItemStyle {
         padding_style,
         label_gap,
@@ -269,7 +270,7 @@ impl<'c> ComposeChild<'c> for ListItem {
         leading_config,
         trailing_config,
         item_align,
-      } = ListItemStyle::of(ctx!());
+      } = ListItemStyle::of(ctx);
 
       let padding = padding_style.map(Padding::new);
       let label_gap = label_gap.map(Padding::new );
@@ -287,7 +288,7 @@ impl<'c> ComposeChild<'c> for ListItem {
                 @Column {
                   @Text {
                     text: headline.0.0,
-                    foreground: Palette::of(ctx!()).on_surface(),
+                    foreground: Palette::of(ctx).on_surface(),
                     text_style: headline_style,
                   }
                   @{ supporting.map(|supporting|  {
@@ -301,7 +302,7 @@ impl<'c> ComposeChild<'c> for ListItem {
                       } ,
                       @Text {
                         text: supporting.0.0,
-                        foreground:  Palette::of(ctx!()).on_surface_variant(),
+                        foreground:  Palette::of(ctx).on_surface_variant(),
                         text_style: supporting_style,
                       }
                     }

--- a/widgets/src/radio.rs
+++ b/widgets/src/radio.rs
@@ -36,24 +36,15 @@ mod tests {
 
   use super::*;
 
-  fn radio_widget(_: &mut BuildCtx) -> Widget<'static> {
-    fn_widget! {
-      @MockMulti {
-        @Radio {
-          checked: false,
-        }
-        @Radio {
-          checked: true,
-        }
-      }
-    }
-    .into_widget()
-  }
-
   widget_image_tests!(
     radio_widget,
-    WidgetTester::new(radio_widget)
-      .with_wnd_size(Size::new(150., 80.))
-      .with_comparison(0.002)
+    WidgetTester::new(fn_widget! {
+      @MockMulti {
+        @Radio { checked: false }
+        @Radio { checked: true }
+      }
+    })
+    .with_wnd_size(Size::new(150., 80.))
+    .with_comparison(0.002)
   );
 }

--- a/widgets/src/tabs.rs
+++ b/widgets/src/tabs.rs
@@ -229,7 +229,7 @@ impl ComposeChild<'static> for Tabs {
     }
 
     fn_widget! {
-      let tabs_style = TabsStyle::of(ctx!());
+      let tabs_style = TabsStyle::of(BuildCtx::get());
         let TabsStyle {
           extent_only_icon,
           extent_only_label,

--- a/widgets/src/text.rs
+++ b/widgets/src/text.rs
@@ -71,7 +71,7 @@ macro_rules! define_text_with_theme_style {
         fn_widget! {
           @Text {
             text: pipe!($this.text.clone()),
-            text_style: TypographyTheme::of(ctx!()).$style.text.clone(),
+            text_style: TypographyTheme::of(BuildCtx::get()).$style.text.clone(),
           }
         }
         .into_widget()

--- a/widgets/src/text_field.rs
+++ b/widgets/src/text_field.rs
@@ -324,7 +324,7 @@ fn build_input_area(
     };
     input_area.get_visibility_widget()
       .map_writer(|w| PartData::from_ref(&w.visible))
-      .transition(transitions::LINEAR.of(ctx!()), ctx!());
+      .transition(transitions::LINEAR.of(ctx!()));
 
     let mut input = @Input{ style: pipe!($theme.text.clone()) };
     $input.write().set_text(&$this.text);
@@ -386,7 +386,7 @@ impl Compose for TextFieldLabel {
       };
 
       this.map_writer(|w| PartData::from_ref(&w.style.font_size))
-        .transition(transitions::LINEAR.of(ctx!()), ctx!());
+        .transition(transitions::LINEAR.of(ctx!()));
 
       label
     }
@@ -407,7 +407,7 @@ fn build_content_area(
     content_area
       .get_padding_widget()
       .map_writer(|w| PartData::from_ref(&w.padding))
-      .transition(transitions::LINEAR.of(ctx!()), ctx!());
+      .transition(transitions::LINEAR.of(ctx!()));
 
     @ $content_area {
       @ {

--- a/widgets/src/text_field.rs
+++ b/widgets/src/text_field.rs
@@ -270,7 +270,8 @@ impl<'c> ComposeChild<'c> for TextField {
       let mut config = config.unwrap_or_default();
       take_option_field!({leading_icon, trailing_icon}, config);
 
-      let theme_suit = TextFieldThemeSuit::of(ctx!());
+      let ctx = BuildCtx::get();
+      let theme_suit = TextFieldThemeSuit::of(ctx);
       let theme = @TextFieldThemeProxy {
         suit: theme_suit,
         state: TextFieldState::default(),
@@ -287,7 +288,7 @@ impl<'c> ComposeChild<'c> for TextField {
           align_items: Align::Stretch,
           @{
             leading_icon.map(|t| @Icon {
-              size: IconSize::of(ctx!()).small,
+              size: IconSize::of(ctx).small,
               @{ t.0 }
             })
           }
@@ -297,7 +298,7 @@ impl<'c> ComposeChild<'c> for TextField {
           }
           @{
             trailing_icon.map(|t| @Icon {
-              size: IconSize::of(ctx!()).small,
+              size: IconSize::of(ctx).small,
               @{ t.0 }
             })
           }
@@ -324,7 +325,7 @@ fn build_input_area(
     };
     input_area.get_visibility_widget()
       .map_writer(|w| PartData::from_ref(&w.visible))
-      .transition(transitions::LINEAR.of(ctx!()));
+      .transition(transitions::LINEAR.of(BuildCtx::get()));
 
     let mut input = @Input{ style: pipe!($theme.text.clone()) };
     $input.write().set_text(&$this.text);
@@ -386,7 +387,7 @@ impl Compose for TextFieldLabel {
       };
 
       this.map_writer(|w| PartData::from_ref(&w.style.font_size))
-        .transition(transitions::LINEAR.of(ctx!()));
+        .transition(transitions::LINEAR.of(BuildCtx::get()));
 
       label
     }
@@ -407,7 +408,7 @@ fn build_content_area(
     content_area
       .get_padding_widget()
       .map_writer(|w| PartData::from_ref(&w.padding))
-      .transition(transitions::LINEAR.of(ctx!()));
+      .transition(transitions::LINEAR.of(BuildCtx::get()));
 
     @ $content_area {
       @ {


### PR DESCRIPTION
## Purpose of this Pull Request

We have introduced the global method `BuildCtx::get` to allow access to the build context from anywhere in the building process. As a result, we removed the `ctx!` macro and the parameter from the function widget.

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.