### PR TITLE
refactor(core): 💡 skip paint for out of bounds widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### Changed
 
 - **core**: Optimize QueryId::is_same by not creating a String using format for every comparison (#678 @tashcan)
+- **core**: Skip paint for out of bounds widgets (#677 @tashcan)
 
 ## [0.4.0-alpha.19] - 2024-12-18
 


### PR DESCRIPTION
## Purpose of this Pull Request

Widgets shouldn't paint outside of their bounds, as such we can just skip painting anything, saving a lot of work
especially for large widget trees with a lot of widgets that are off-screen.
Additionally, since saving the painter state isn't entirely free, we can also skip doing that when we aren't painting anything.

## Checklist Before Merging

Please ensure the following are completed before merging:
- [X] If this is linked to an issue, include the link in your description.
- [X] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [X] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.