### PR TITLE
Fix broken documentation link in cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 **crate or effect scope**: description of change (#pr @contributor)
 ```
 
-1.  When creating a pull request, `#pr` will automatically update with the pull request number.
-2.  Replace `@contributor` with your GitHub username.
+1. When creating a pull request, `#pr` will automatically update with the pull request number.
+2. Replace `@contributor` with your GitHub username.
 
 <!-- next-header -->
 
 ## [@Unreleased] - @ReleaseDate
+
+### Fixed
+
+- cargo: Fixed Documentation link (#686 @EpixMan)
 
 ## [0.4.0-alpha.21] - 2025-01-01
 
@@ -99,7 +103,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 - **widgets**: The `Checkbox` widget uses classes to style and simplify its label syntax. (#666 @M-Adoo)
 - **widgets**: The `Icon` widget utilizes classes to configure its style, and it does not have a size property. (#660 @M-Adoo)
 - **theme:** Refactor the `Ripple` and `StateLayer` of the material theme to enhance their visual effects. (#666 @M-Adoo)
-
 
 ### Fixed
 
@@ -196,7 +199,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 - **core**: Merged boolean status widgets into a single widget `MixFlags`, including `HasFocus`, `MouseHover` and `PointerPressed`. (#627 @M-Adoo)
 - **core**: Reimplemented `HAlignWidget`, `VAlignWidget`, `RelativeAnchor`, `BoxDecoration`, `ConstrainedBox`, `IgnorePoint`, `Opacity`, `Padding`, `TransformWidget`, and `VisibilityRender` as `WrapRender`. (#626 @M-Adoo)
 
-
 ### Fixed
 
 - **core**: The `SplitWriter` and `MapWriter` of the render widget may not be flagged as dirty. (#626, @M-Adoo)
@@ -204,7 +206,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### Breaking
 
 - **painter**: Removed `Painter::brush` and `Painter::set_brush`, now using `fill_brush`, `stroke_brush`, `set_fill_brush`, and `set_stroke_brush` methods instead. (#628 @M-Adoo)
-
 
 ## [0.4.0-alpha.9] - 2024-09-18
 
@@ -245,7 +246,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 - **widgets**: Flex may not decrease the gap for the second child during layout. (#622 @M-Adoo)
 
-
 ## [0.4.0-alpha.6] - 2024-08-21
 
 ### Features
@@ -277,6 +277,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
   ```
 
 - **core**: Added `Provider` widget to share data between sub-tree. (#618 @M-Adoo)
+
   ```rust
   Provider::new(Box::new(State::value(0i32))).with_child(fn_widget! {
     @SizedBox {
@@ -317,7 +318,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 - **core**: Removed unnecessary `Writer` since it has the same capabilities as `Stateful`. (#615 @M-Adoo)
 
-
 ## [0.4.0-alpha.4] - 2024-08-07
 
 ### Features
@@ -347,7 +347,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 - Removed the all builder traits such as WidgetBuilder and ComposeBuilder and so on. (#612 @M-Adoo)
 - All implicit child conversions have been removed, except for conversions to Widget. (#612 @M-Adoo)
 
-
 ## [0.4.0-alpha.3] - 2024-06-26
 
 ## [0.4.0-alpha.2] - 2024-06-19
@@ -357,6 +356,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 - **core**: Added support to query a `WriteRef` from a state, enabling users to modify the state after attaching it to a widget. (#601 @M-Adoo)
 - **core**: Introduced the `DeclareInto` trait for any type that implements `DeclareFrom`. (#604 @M-Adoo)
 - **macros**: Improved widget declaration to allow specifying widget types via path. (#606 @M-Adoo)
+
   ```rust
     // Previously, a widget type could only be specified using an identifier, requiring prior import of `Row`.
     use ribir::prelude::*;
@@ -381,7 +381,6 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### BREAKING
 
 - **core**: Removed the infrequently used `StateFrom` trait, as there's a more efficient alternative. (#604 @M-Adoo)
-
 
 ## [0.4.0-alpha.1](https://github.com/RibirX/Ribir/compare/ribir-v0.3.0-beta.2...ribir-v0.4.0-alpha.1) - 2024-06-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ debug = true
 
 [profile.release]
 lto = true
-strip = true  
+strip = true
 codegen-units = 1
 
 [workspace.package]
 authors = ["RibirX<Adoo@outlook.com>"]
 categories = ["gui"]
 description = "A non-intrusive declarative GUI framework, to build modern native/wasm cross-platform applications."
-documentation = "https://ribir.org/docs"
+documentation = "https://ribir.org/docs/introduction"
 edition = "2021"
 homepage = "https://ribir.org"
 keywords = ["gui", "ui", "declarative", "compose-ui"]
@@ -45,7 +45,7 @@ bitflags = "2.6.0"
 blake3 = "1.3.3"
 colored = "2.1.0"
 derive_more = "1.0.0"
-dssim-core="3.2.9"
+dssim-core = "3.2.9"
 env_logger = "0.7.1"
 euclid = "0.22.11"
 fontdb = "0.23.0"
@@ -66,7 +66,9 @@ proc-macro2 = "1.0.89"
 quote = "1.0.37"
 rayon = "1.10.0"
 rustybuzz = "0.20.1"
-rxrust = { version="1.0.0-beta.9", default-features = false, features = ["futures-scheduler"]}
+rxrust = { version = "1.0.0-beta.9", default-features = false, features = [
+  "futures-scheduler",
+] }
 scoped_threadpool = "0.1.9"
 triomphe = "0.1.12"
 serde = "1.0"
@@ -76,10 +78,15 @@ syn = "2.0.87"
 unicode-bidi = "0.3.7"
 unicode-script = "0.5.4"
 unicode-segmentation = "1.9.0"
-usvg = { version= "0.44.0", default-features = false }
+usvg = { version = "0.44.0", default-features = false }
 webbrowser = "0.8.8"
-wgpu = {version = "0.20.0", features=["webgl"]}
-winit = { version="0.29.5", default-features = false, features = ["x11", "wayland", "wayland-dlopen", "rwh_06"]}
+wgpu = { version = "0.20.0", features = ["webgl"] }
+winit = { version = "0.29.5", default-features = false, features = [
+  "x11",
+  "wayland",
+  "wayland-dlopen",
+  "rwh_06",
+] }
 zerocopy = "0.7.3"
 quick-xml = "0.37.1"
 macos-accessibility-client = { version = "0.0.1" }


### PR DESCRIPTION
## Purpose of this Pull Request
This pull request is to fix #685 by changing cargo.toml docs link, as suggested by @M-Adoo.
