### PR TITLE
Fix empty window after switching in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ## [@Unreleased] - @ReleaseDate
 
 ### Features
-- **core**: Add the ability to force redraw a frame. (#pr @zihadmahiuddin)
+- **core**: Add the ability to force redraw a frame. (#697 @zihadmahiuddin)
+
+### Fixed
+- **core**: Fix window staying empty after switching workspace (e.g. in i3wm) by doing a force redraw. (#697 @zihadmahiuddin)
 
 ## [0.4.0-alpha.26] - 2025-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## [@Unreleased] - @ReleaseDate
 
+### Features
+- **core**: Add the ability to force redraw a frame. (#pr @zihadmahiuddin)
+
 ## [0.4.0-alpha.26] - 2025-02-05
 
 ### Fixed

--- a/core/src/test_helper.rs
+++ b/core/src/test_helper.rs
@@ -105,7 +105,7 @@ impl TestWindow {
     self.run_frame_tasks();
 
     AppCtx::frame_ticks().clone().next(Instant::now());
-    self.0.draw_frame();
+    self.0.draw_frame(false);
   }
 }
 

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -217,7 +217,7 @@ impl Window {
 
   /// Draw an image what current render tree represent.
   #[track_caller]
-  pub fn draw_frame(&self) -> bool {
+  pub fn draw_frame(&self, force: bool) -> bool {
     AppCtx::run_until_stalled();
     let mut ticker = self.frame_ticker.clone();
     ticker.next(FrameMsg::NewFrame(Instant::now()));
@@ -225,7 +225,7 @@ impl Window {
 
     self.update_painter_viewport();
     let draw = self.need_draw() && !self.size().is_empty();
-    if draw {
+    if force || draw {
       let root = self.tree().root();
 
       let surface = {

--- a/ribir/src/app.rs
+++ b/ribir/src/app.rs
@@ -108,7 +108,7 @@ impl App {
               if wnd.is_visible() != Some(false) {
                 // if this frame is really draw, request another redraw. To make sure the draw
                 // always end with a empty draw and emit an extra tick cycle message.
-                if wnd.draw_frame() {
+                if wnd.draw_frame(false) {
                   request_redraw(&wnd);
                 }
               }

--- a/ribir/src/app.rs
+++ b/ribir/src/app.rs
@@ -100,6 +100,13 @@ impl App {
               loop_handle.exit();
             }
           }
+          WindowEvent::Occluded(false) => {
+            // this is triggered before the app re-enters view
+            // for example, in something like i3 window manager,
+            // when you switch back to the workspace that the app is in
+            // in such cases, we need to re-enter the view otherwise the window stays empty
+            wnd.draw_frame(true);
+          }
           WindowEvent::RedrawRequested => {
             AppCtx::frame_ticks().clone().next(Instant::now());
 


### PR DESCRIPTION
## Purpose of this Pull Request

In some cases, Ribir wouldn't redraw the window even when a redraw event would be emitted.
For example, on my i3 setup if I go to another workspace and come back, the app wouldn't redraw and the window would stay blank.

Here is a video:

https://github.com/user-attachments/assets/ef7923bb-1c52-459f-b539-8b038f5634d2

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [ ] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.

I think changing `Window::draw_frame`'s signature might count as breaking, let me know if it is, I'll edit the change log to reflect that.