### PR TITLE
feat(core): 🎸 record the visual rect after layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,12 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ## [0.4.0-alpha.27] - 2025-02-12
 
 ### Features
+
 - **core**: Add the ability to force redraw a frame. (#697 @zihadmahiuddin)
+- **core**: record the visual rect after layout.(#pr @wjian23)
 
 ### Fixed
+
 - **core**: Fix window staying empty after switching workspace (e.g. in i3wm) by doing a force redraw. (#697 @zihadmahiuddin)
 
 ## [0.4.0-alpha.26] - 2025-02-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,18 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## [@Unreleased] - @ReleaseDate
 
+### Features
+- **core**: record the visual rect after layout.(#698 @wjian23)
+
+### Fixed
+- **core**: fix miss pop providers when call `push_providers_for` separately during layout.(#698 @wjian23)
+
 ## [0.4.0-alpha.27] - 2025-02-12
 
 ### Features
 
 - **core**: Add the ability to force redraw a frame. (#697 @zihadmahiuddin)
-- **core**: record the visual rect after layout.(#pr @wjian23)
+
 
 ### Fixed
 

--- a/core/src/builtin_widgets/align.rs
+++ b/core/src/builtin_widgets/align.rs
@@ -113,6 +113,10 @@ impl WrapRender for VAlignWidget {
     // ignores the constraint, the align widget should do the same.
     host_size
   }
+
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    host.visual_box(ctx)
+  }
 }
 
 impl Align {

--- a/core/src/builtin_widgets/background.rs
+++ b/core/src/builtin_widgets/background.rs
@@ -38,6 +38,16 @@ impl WrapRender for Background {
     }
     host.paint(ctx);
   }
+
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    let visual_box = host.visual_box(ctx);
+    let size = ctx.box_size().unwrap();
+    if visual_box.is_none() {
+      Some(Rect::from_size(size))
+    } else {
+      visual_box.map(|rect| rect.union(&Rect::from_size(size)))
+    }
+  }
 }
 
 impl_compose_child_for_wrap_render!(Background, DirtyPhase::Paint);

--- a/core/src/builtin_widgets/border.rs
+++ b/core/src/builtin_widgets/border.rs
@@ -69,6 +69,16 @@ impl WrapRender for BorderWidget {
     host.perform_layout(clamp, ctx)
   }
 
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    let visual_box = host.visual_box(ctx);
+    let size = ctx.box_size().unwrap();
+    if visual_box.is_none() {
+      Some(Rect::from_size(size))
+    } else {
+      visual_box.map(|rect| rect.union(&Rect::from_size(size)))
+    }
+  }
+
   fn paint(&self, host: &dyn Render, ctx: &mut PaintingCtx) {
     let size = ctx.box_size().unwrap();
 

--- a/core/src/builtin_widgets/clip.rs
+++ b/core/src/builtin_widgets/clip.rs
@@ -19,4 +19,10 @@ impl Render for Clip {
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) { ctx.painter().clip(self.clip_path.clone().into()); }
+
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let clip_rect = self.clip_path.bounds(None);
+    ctx.clip(clip_rect);
+    Some(clip_rect)
+  }
 }

--- a/core/src/builtin_widgets/clip_boundary.rs
+++ b/core/src/builtin_widgets/clip_boundary.rs
@@ -43,6 +43,12 @@ impl WrapRender for ClipBoundary {
     }
     host.paint(ctx)
   }
+
+  fn visual_box(&self, _: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    let clip_rect = Rect::from_size(ctx.box_size().unwrap());
+    ctx.clip(clip_rect);
+    Some(clip_rect)
+  }
 }
 
 #[cfg(test)]

--- a/core/src/builtin_widgets/fitted_box.rs
+++ b/core/src/builtin_widgets/fitted_box.rs
@@ -83,6 +83,12 @@ impl Render for FittedBox {
     clamp.clamp(size)
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let clip_rect = Rect::from_size(ctx.box_size().unwrap());
+    ctx.clip(clip_rect);
+    Some(clip_rect)
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let scale = self.scale_cache.get();
     if matches!(self.box_fit, BoxFit::Cover) {

--- a/core/src/builtin_widgets/ignore_pointer.rs
+++ b/core/src/builtin_widgets/ignore_pointer.rs
@@ -22,11 +22,6 @@ pub enum IgnoreScope {
 impl_compose_child_for_wrap_render!(IgnorePointer, DirtyPhase::Paint);
 
 impl WrapRender for IgnorePointer {
-  #[inline]
-  fn perform_layout(&self, clamp: BoxClamp, host: &dyn Render, ctx: &mut LayoutCtx) -> Size {
-    host.perform_layout(clamp, ctx)
-  }
-
   fn hit_test(&self, host: &dyn Render, ctx: &mut HitTestCtx, pos: Point) -> HitTest {
     match self.ignore {
       IgnoreScope::Subtree => HitTest { hit: false, can_hit_child: false },

--- a/core/src/builtin_widgets/image_widget.rs
+++ b/core/src/builtin_widgets/image_widget.rs
@@ -15,4 +15,10 @@ impl Render for Resource<PixelImage> {
       painter.draw_img(self.clone(), &rc, &Some(rc));
     }
   }
+
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let box_rect = Rect::from_size(ctx.box_size().unwrap());
+    let img_rect = Rect::from_size(Size::new(self.width() as f32, self.height() as f32));
+    img_rect.intersection(&box_rect)
+  }
 }

--- a/core/src/builtin_widgets/opacity.rs
+++ b/core/src/builtin_widgets/opacity.rs
@@ -19,14 +19,19 @@ impl Default for Opacity {
 impl_compose_child_for_wrap_render!(Opacity, DirtyPhase::Paint);
 
 impl WrapRender for Opacity {
-  fn perform_layout(&self, clamp: BoxClamp, host: &dyn Render, ctx: &mut LayoutCtx) -> Size {
-    host.perform_layout(clamp, ctx)
-  }
-
   fn paint(&self, host: &dyn Render, ctx: &mut PaintingCtx) {
     ctx.painter().apply_alpha(self.opacity);
     if self.opacity > 0. {
       host.paint(ctx)
+    }
+  }
+
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    if self.opacity > 0. {
+      host.visual_box(ctx)
+    } else {
+      ctx.clip(Rect::from_size(Size::zero()));
+      None
     }
   }
 }

--- a/core/src/builtin_widgets/padding.rs
+++ b/core/src/builtin_widgets/padding.rs
@@ -50,6 +50,15 @@ impl WrapRender for Padding {
     host.paint(ctx);
   }
 
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    host
+      .visual_box(ctx)
+      .map_or(Some(Rect::from_size(ctx.box_size().unwrap())), |mut rect| {
+        rect.size += self.padding.thickness();
+        Some(rect)
+      })
+  }
+
   fn get_transform(&self, host: &dyn Render) -> Option<Transform> {
     let padding_matrix = Transform::translation(self.padding.left, self.padding.top);
 

--- a/core/src/builtin_widgets/providers.rs
+++ b/core/src/builtin_widgets/providers.rs
@@ -677,6 +677,8 @@ impl Render for ProvidersRender {
     size
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> { self.render.visual_box(ctx) }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let Self { render, providers } = self;
     let id = ctx.id();

--- a/core/src/builtin_widgets/scrollable.rs
+++ b/core/src/builtin_widgets/scrollable.rs
@@ -258,6 +258,12 @@ impl Render for Viewport {
 
     ctx.painter().clip(path.into());
   }
+
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let clip_rect = Rect::from_size(self.size.get());
+    ctx.clip(clip_rect);
+    Some(clip_rect)
+  }
 }
 
 #[cfg(test)]

--- a/core/src/builtin_widgets/svg.rs
+++ b/core/src/builtin_widgets/svg.rs
@@ -4,6 +4,10 @@ impl Render for Svg {
   #[inline]
   fn perform_layout(&self, clamp: BoxClamp, _: &mut LayoutCtx) -> Size { clamp.clamp(self.size()) }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    Some(Rect::from_size(ctx.box_size().unwrap()))
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let size = ctx.box_size().unwrap();
     let painter = ctx.painter();

--- a/core/src/builtin_widgets/text.rs
+++ b/core/src/builtin_widgets/text.rs
@@ -51,21 +51,24 @@ pub fn paint_text(
 impl Render for Text {
   fn perform_layout(&self, clamp: BoxClamp, ctx: &mut LayoutCtx) -> Size {
     let style = Provider::of::<TextStyle>(ctx).unwrap();
-    let info = AppCtx::typography_store()
-      .borrow_mut()
-      .typography(
-        self.text.substr(..),
-        &style,
-        clamp.max,
-        self.text_align,
-        GlyphBaseline::Middle,
-        PlaceLineDirection::TopToBottom,
-      );
 
-    let size = info.visual_rect().size;
-    *self.glyphs.borrow_mut() = Some(info);
+    let glyphs = text_glyph(self.text.substr(..), &style, self.text_align, clamp.max);
+
+    let size = glyphs.visual_rect().size;
+    *self.glyphs.borrow_mut() = Some(glyphs);
 
     clamp.clamp(size)
+  }
+
+  fn visual_box(&self, _: &mut VisualCtx) -> Option<Rect> {
+    Some(
+      self
+        .glyphs
+        .borrow()
+        .as_ref()
+        .map(|info| info.visual_rect())
+        .unwrap_or_default(),
+    )
   }
 
   #[inline]

--- a/core/src/builtin_widgets/transform_widget.rs
+++ b/core/src/builtin_widgets/transform_widget.rs
@@ -19,6 +19,14 @@ impl WrapRender for TransformWidget {
     host.perform_layout(clamp, ctx)
   }
 
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    host
+      .visual_box(ctx)
+      .map_or(Some(Rect::from_size(ctx.box_size().unwrap())), |rect| {
+        Some(self.transform.outer_transformed_rect(&rect))
+      })
+  }
+
   fn paint(&self, host: &dyn Render, ctx: &mut PaintingCtx) {
     ctx.painter().apply_transform(&self.transform);
     host.paint(ctx)

--- a/core/src/builtin_widgets/visibility.rs
+++ b/core/src/builtin_widgets/visibility.rs
@@ -41,6 +41,15 @@ impl WrapRender for VisibilityRender {
     if self.display { host.perform_layout(clamp, ctx) } else { clamp.min }
   }
 
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    if self.display {
+      host.visual_box(ctx)
+    } else {
+      ctx.clip(Rect::from_size(Size::zero()));
+      None
+    }
+  }
+
   fn paint(&self, host: &dyn Render, ctx: &mut PaintingCtx) {
     if self.display {
       host.paint(ctx)

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,8 +1,10 @@
 mod painting_ctx;
 pub use painting_ctx::PaintingCtx;
 mod layout_ctx;
+mod visual_ctx;
 mod widget_ctx;
 pub use layout_ctx::*;
+pub use visual_ctx::*;
 pub use widget_ctx::*;
 pub(crate) mod build_ctx;
 pub use build_ctx::BuildCtx;

--- a/core/src/context/layout_ctx.rs
+++ b/core/src/context/layout_ctx.rs
@@ -59,6 +59,7 @@ impl<'a> LayoutCtx<'a> {
       VisualCtx::from_layout_ctx(self).update_visual_box();
     }
 
+    self.provider_ctx.pop_providers_for(self.id());
     self
       .window()
       .add_delay_event(DelayEvent::PerformedLayout(id));
@@ -68,7 +69,7 @@ impl<'a> LayoutCtx<'a> {
 
   /// Perform layout of the `child` and return its size.
   pub fn perform_child_layout(&mut self, child: WidgetId, clamp: BoxClamp) -> Size {
-    let size = self
+    self
       .get_calculated_size(child, clamp)
       .unwrap_or_else(|| {
         // The position needs to be reset, as some parent render widgets may not have
@@ -80,10 +81,7 @@ impl<'a> LayoutCtx<'a> {
         self.id = id;
 
         size
-      });
-    self.provider_ctx.pop_providers_for(self.id);
-
-    size
+      })
   }
 
   /// Adjust the position of the widget where it should be placed relative to

--- a/core/src/context/visual_ctx.rs
+++ b/core/src/context/visual_ctx.rs
@@ -1,0 +1,108 @@
+use ribir_geom::{Point, Rect, Size};
+
+use super::{LayoutCtx, WidgetCtxImpl};
+use crate::{
+  prelude::ProviderCtx,
+  widget::{VisualBox, WidgetTree},
+  widget_tree::WidgetId,
+};
+pub struct VisualCtx<'a> {
+  id: WidgetId,
+  tree: &'a mut WidgetTree,
+  provider_ctx: &'a mut ProviderCtx,
+  clip_area: Option<Rect>,
+}
+
+impl<'a> WidgetCtxImpl for VisualCtx<'a> {
+  #[inline]
+  fn id(&self) -> WidgetId { self.id }
+
+  #[inline]
+  fn tree(&self) -> &WidgetTree { self.tree }
+}
+
+impl<'a> VisualCtx<'a> {
+  pub(crate) fn from_layout_ctx<'c: 'a, 'b: 'a>(ctx: &'c mut LayoutCtx<'b>) -> Self {
+    let id = ctx.id();
+    let LayoutCtx { provider_ctx, tree, .. } = ctx;
+    Self { id, tree: *tree, provider_ctx, clip_area: None }
+  }
+
+  pub fn update_visual_box(&mut self) -> VisualBox {
+    let id = self.id();
+
+    let tree = unsafe { &*(self.tree as *mut WidgetTree) };
+    let w = id.assert_get(tree);
+    let rect = w.visual_box(self);
+
+    let mut subtree = self.descendants_bounds();
+    if let Some(clip) = &self.clip_area {
+      subtree = subtree.and_then(|rect| clip.intersection(&rect));
+    }
+    if let Some(transform) = w.get_transform() {
+      subtree = subtree.map(|rect| transform.outer_transformed_rect(&rect));
+    }
+
+    let visual_box = VisualBox { rect, subtree };
+
+    let info = self.tree.store.layout_info_or_default(id);
+    info.visual_box = visual_box;
+    info.visual_box
+  }
+
+  pub fn descendants_bounds(&self) -> Option<Rect> {
+    let id = self.id;
+    let children = id.children(self.tree);
+
+    let mut rect = None;
+    for child in children {
+      if let Some(mut child_view) = self.visual_rect(child) {
+        let pos = self
+          .position(child)
+          .expect("child position should be set");
+
+        child_view.origin += pos.to_vector();
+        if rect.is_none() {
+          rect = Some(child_view);
+        } else {
+          rect = rect.map(|rect| rect.union(&child_view));
+        }
+      }
+    }
+    rect
+  }
+
+  pub fn clip(&mut self, rect: Rect) {
+    self.clip_area = self
+      .clip_area
+      .and_then(|r| {
+        r.intersection(&rect)
+          .or(Some(Rect::from_size(Size::zero())))
+      })
+      .or(Some(rect));
+  }
+
+  fn visual_rect(&self, id: WidgetId) -> Option<Rect> {
+    self
+      .tree
+      .store
+      .layout_info(id)
+      .and_then(|info| info.visual_box.bounds_rect())
+  }
+
+  fn position(&self, id: WidgetId) -> Option<Point> {
+    self
+      .tree
+      .store
+      .layout_info(id)
+      .map(|info| info.pos)
+  }
+}
+
+impl<'w> AsRef<ProviderCtx> for VisualCtx<'w> {
+  fn as_ref(&self) -> &ProviderCtx { self.provider_ctx }
+}
+
+impl<'w> AsMut<ProviderCtx> for VisualCtx<'w> {
+  fn as_mut(&mut self) -> &mut ProviderCtx { self.provider_ctx }
+}

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -854,6 +854,8 @@ impl Render for PipeNode {
     self.as_ref().data.perform_layout(clamp, ctx)
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> { self.as_ref().data.visual_box(ctx) }
+
   fn paint(&self, ctx: &mut PaintingCtx) { self.as_ref().data.paint(ctx) }
 
   fn only_sized_by_parent(&self) -> bool {

--- a/core/src/render_helper.rs
+++ b/core/src/render_helper.rs
@@ -37,6 +37,9 @@ where
   }
 
   #[inline]
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> { self.proxy().visual_box(ctx) }
+
+  #[inline]
   fn paint(&self, ctx: &mut PaintingCtx) { self.proxy().paint(ctx) }
 
   #[inline]

--- a/core/src/test_helper.rs
+++ b/core/src/test_helper.rs
@@ -268,6 +268,7 @@ pub struct LayoutCase {
   y: Option<f32>,
   width: Option<f32>,
   height: Option<f32>,
+  visual_rect: Option<Rect>,
 }
 
 impl LayoutCase {
@@ -332,11 +333,16 @@ impl LayoutCase {
     self
   }
 
+  pub fn with_visual_rect(mut self, rect: Rect) -> Self {
+    self.visual_rect = Some(rect);
+    self
+  }
+
   pub fn with_rect(self, rect: Rect) -> Self { self.with_pos(rect.origin).with_size(rect.size) }
 
   #[track_caller]
   pub fn check(&self, wnd: &TestWindow) {
-    let Self { path, x, y, width, height } = self;
+    let Self { path, x, y, width, height, visual_rect } = self;
 
     let info = wnd.layout_info_by_path(path).unwrap();
     if let Some(x) = x {
@@ -350,6 +356,9 @@ impl LayoutCase {
     }
     if let Some(h) = height {
       assert_eq!(info.size.unwrap().height, *h, "unexpected height");
+    }
+    if let Some(rect) = visual_rect {
+      assert_eq!(info.visual_box.bounds_rect(), Some(*rect), "unexpected visual rect");
     }
   }
 }
@@ -412,5 +421,7 @@ impl WidgetTester {
 }
 
 impl Default for LayoutCase {
-  fn default() -> Self { Self { path: &[0], x: None, y: None, width: None, height: None } }
+  fn default() -> Self {
+    Self { path: &[0], x: None, y: None, width: None, height: None, visual_rect: None }
+  }
 }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -71,6 +71,23 @@ pub trait Render: 'static {
 
   /// Return a transform to map the coordinate to parent coordinate.
   fn get_transform(&self) -> Option<Transform> { None }
+
+  /// Computes the visual bounding box of the widget relative to self.
+  /// The method is called by framework after the layout is done.
+  /// Usually if you paint something, you should return the bounding box of the
+  /// paint. Default implementation will return None which means the
+  /// current widget will not be rendered.
+  ///
+  ///
+  /// Parameters:
+  ///
+  /// * `ctx`: The VisualCtx.
+  ///
+  /// Returns:
+  ///
+  /// The visual bounding box of the widget.
+  #[allow(unused_variables)]
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> { None }
 }
 
 /// The common type of all widget can convert to.

--- a/core/src/widget_tree/layout_info.rs
+++ b/core/src/widget_tree/layout_info.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ribir_geom::ZERO_SIZE;
+use ribir_geom::{Rect, ZERO_SIZE};
 
 use super::{Lerp, WidgetId, WidgetTree};
 use crate::prelude::{INFINITY_SIZE, Point, Size};
@@ -87,6 +87,25 @@ impl BoxClamp {
   }
 }
 
+#[derive(Default, Debug, Clone, PartialEq, Copy)]
+pub struct VisualBox {
+  /// the bounds rect of the render object
+  pub rect: Option<Rect>,
+  /// the bounds rect of the subtree
+  pub subtree: Option<Rect>,
+}
+
+impl VisualBox {
+  pub fn bounds_rect(&self) -> Option<Rect> {
+    match (self.rect, self.subtree) {
+      (Some(rect), Some(subtree)) => Some(rect.union(&subtree)),
+      (Some(rect), None) => Some(rect),
+      (None, Some(subtree)) => Some(subtree),
+      (None, None) => None,
+    }
+  }
+}
+
 /// render object's layout box, the information about layout, including box
 /// size, box position, and the clamp of render object layout.
 #[derive(Debug, Default, Clone)]
@@ -99,6 +118,9 @@ pub struct LayoutInfo {
   pub size: Option<Size>,
   /// The position render object to place, default is zero
   pub pos: Point,
+
+  /// the visual box of the render object
+  pub visual_box: VisualBox,
 }
 
 /// Store the render object's place relative to parent coordinate and the

--- a/core/src/wrap_render.rs
+++ b/core/src/wrap_render.rs
@@ -31,6 +31,10 @@ pub trait WrapRender {
 
   fn get_transform(&self, host: &dyn Render) -> Option<Transform> { host.get_transform() }
 
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    host.visual_box(ctx)
+  }
+
   fn combine_child(
     this: impl StateWriter<Value = Self>, mut child: Widget, dirty: DirtyPhase,
   ) -> Widget
@@ -89,6 +93,12 @@ impl Render for RenderPair {
       .perform_layout(clamp, self.host.as_render(), ctx)
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    self
+      .wrapper
+      .visual_box(self.host.as_render(), ctx)
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) { self.wrapper.paint(self.host.as_render(), ctx); }
 
   fn only_sized_by_parent(&self) -> bool {
@@ -129,6 +139,10 @@ where
 
   fn get_transform(&self, host: &dyn Render) -> Option<Transform> {
     self.read().get_transform(host)
+  }
+
+  fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
+    self.read().visual_box(host, ctx)
   }
 }
 

--- a/themes/material/src/state_layer.rs
+++ b/themes/material/src/state_layer.rs
@@ -86,6 +86,10 @@ impl<'c, const M: u8> ComposeChild<'c> for StateLayer<M> {
 impl<const M: u8> Render for StateLayer<M> {
   fn perform_layout(&self, clamp: BoxClamp, _: &mut LayoutCtx) -> Size { clamp.min }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    Some(Rect::from_size(ctx.box_size().unwrap()))
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let StateLayer { area, draw_opacity } = self;
     if *draw_opacity > 0. {

--- a/widgets/src/divider.rs
+++ b/widgets/src/divider.rs
@@ -71,21 +71,31 @@ impl Render for Divider {
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) {
-    let mut size = ctx.box_size().unwrap();
-    let (origin, size) = if self.direction.is_horizontal() {
-      size.width -= self.indent + self.end_indent;
-      size.height = self.thickness;
-      let y = (self.extent - self.thickness) / 2.;
-      (Point::new(self.indent, y), size)
-    } else {
-      size.width = self.thickness;
-      size.height -= self.indent + self.end_indent;
-      let x = (self.extent - self.thickness) / 2.;
-      (Point::new(x, self.indent), size)
-    };
+    let rect = self.paint_rect(ctx.box_size().unwrap());
     let painter = ctx.painter();
     painter.set_fill_brush(self.color.clone());
-    painter.rect(&Rect::new(origin, size));
+    painter.rect(&rect);
     painter.fill();
+  }
+
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let rect = self.paint_rect(ctx.box_size().unwrap());
+    Some(rect)
+  }
+}
+
+impl Divider {
+  fn paint_rect(&self, mut box_size: Size) -> Rect {
+    if self.direction.is_horizontal() {
+      box_size.width -= self.indent + self.end_indent;
+      box_size.height = self.thickness;
+      let y = (self.extent - self.thickness) / 2.;
+      Rect::new(Point::new(self.indent, y), box_size)
+    } else {
+      box_size.width = self.thickness;
+      box_size.height -= self.indent + self.end_indent;
+      let x = (self.extent - self.thickness) / 2.;
+      Rect::new(Point::new(x, self.indent), box_size)
+    }
   }
 }

--- a/widgets/src/icon.rs
+++ b/widgets/src/icon.rs
@@ -117,6 +117,10 @@ impl Render for IconRender {
     clamp.clamp(Size::splat(icon_size))
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    Some(Rect::from_size(ctx.box_size().unwrap()))
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let child_size = ctx.single_child_box().unwrap().size;
     if !child_size.is_empty() {

--- a/widgets/src/input/text_glyphs.rs
+++ b/widgets/src/input/text_glyphs.rs
@@ -70,7 +70,12 @@ impl<T: VisualText + 'static> Render for TextGlyphs<T> {
     let glyphs = self.text.layout_glyphs(clamp, ctx);
     let size = glyphs.visual_rect().size;
     *self.glyphs.borrow_mut() = Some(glyphs);
-    clamp.clamp(size)
+    size
+  }
+
+  fn visual_box(&self, _: &mut VisualCtx) -> Option<Rect> {
+    let visual_glyphs = self.glyphs().unwrap();
+    Some(visual_glyphs.visual_rect())
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) {

--- a/widgets/src/path.rs
+++ b/widgets/src/path.rs
@@ -11,6 +11,8 @@ impl Render for PathPaintKit {
   #[inline]
   fn perform_layout(&self, _: BoxClamp, _: &mut LayoutCtx) -> Size { Size::zero() }
 
+  fn visual_box(&self, _: &mut VisualCtx) -> Option<Rect> { Some(self.path.bounds(None)) }
+
   #[inline]
   fn only_sized_by_parent(&self) -> bool { true }
 

--- a/widgets/src/progress.rs
+++ b/widgets/src/progress.rs
@@ -122,6 +122,11 @@ impl Render for SpinnerArc {
     clamp.max.min(wnd_size)
   }
 
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    let size = ctx.box_size().unwrap();
+    Some(Rect::from_size(size))
+  }
+
   fn paint(&self, ctx: &mut PaintingCtx) {
     let Self { start, end } = *self;
     let size = ctx.box_size().unwrap();

--- a/widgets/src/transform_box.rs
+++ b/widgets/src/transform_box.rs
@@ -28,7 +28,12 @@ impl Render for TransformBox {
   }
 
   #[inline]
-  fn paint(&self, _: &mut PaintingCtx) {}
+  fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
+    Some(Rect::from_size(ctx.box_size().unwrap()))
+  }
+
+  #[inline]
+  fn paint(&self, ctx: &mut PaintingCtx) { ctx.painter().apply_transform(&self.matrix); }
 }
 
 impl TransformBox {


### PR DESCRIPTION
## Purpose of this Pull Request

*Please briefly describe what this Pull Request is aiming to achieve.*
Calculate and record the visual area of the Widget after layout. Can be use to skip paint for out of bounds widgets, See [#677]

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.