### PR TITLE
fix(core): 🐛 enables embedding declare template as child in widget with Vec of template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ### Fixed
 - **core**: fix miss pop providers when call `push_providers_for` separately during layout.(#698 @wjian23)
+- **core**: enables embedding declare template as child in widget with Vec of template(#704 @wjian23)
 
 ## [0.4.0-alpha.27] - 2025-02-12
 

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -1203,7 +1203,7 @@ impl<T: MultiChild> MultiChild for DeclarerWithSubscription<T> {
   fn into_parent(self: Box<Self>) -> Widget<'static> { (*self).into_widget() }
 }
 
-impl<'w, T, C, const TML: bool, const WRITER: bool, const N: usize, const M: usize>
+impl<'w, T, C, const TML: usize, const WRITER: bool, const N: usize, const M: usize>
   ComposeWithChild<'w, C, WRITER, TML, N, M> for DeclarerWithSubscription<T>
 where
   T: ComposeWithChild<'w, C, WRITER, TML, N, M>,

--- a/macros/src/child_template.rs
+++ b/macros/src/child_template.rs
@@ -70,7 +70,7 @@ pub(crate) fn derive_child_template(input: &mut syn::DeriveInput) -> syn::Result
         let gen = with_child_generics(generics, ty);
         let (g_impl, _, g_where) = gen.split_for_impl();
         tokens.extend(quote! {
-          impl #g_impl ComposeWithChild<'_c, _C, false, true, {#f_idx + 1}, _M>
+          impl #g_impl ComposeWithChild<'_c, _C, false, 1, {#f_idx + 1}, _M>
             for #builder #g_ty #g_where
           {
             type Target = Self;
@@ -177,7 +177,7 @@ pub(crate) fn derive_child_template(input: &mut syn::DeriveInput) -> syn::Result
             let gen = with_child_generics(generics, ty);
             let (g_impl, _, g_where) = gen.split_for_impl();
             tokens.extend(quote! {
-              impl #g_impl ComposeWithChild<'_c, _C, false, true, {#i + 1}, _M>
+              impl #g_impl ComposeWithChild<'_c, _C, false, 1, {#i + 1}, _M>
                 for #builder #g_ty #g_where
               {
                 type Target = Self;


### PR DESCRIPTION
enables embedding declare template as child in widget with Vec of template

## Purpose of this Pull Request

*Please briefly describe what this Pull Request is aiming to achieve.*

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.