### PR TITLE
fix(core): prevent panic in visual_box layout code

### DIFF
--- a/core/src/builtin_widgets/background.rs
+++ b/core/src/builtin_widgets/background.rs
@@ -41,7 +41,7 @@ impl WrapRender for Background {
 
   fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
     let visual_box = host.visual_box(ctx);
-    let size = ctx.box_size().unwrap();
+    let size = ctx.box_size()?;
     if visual_box.is_none() {
       Some(Rect::from_size(size))
     } else {

--- a/core/src/builtin_widgets/border.rs
+++ b/core/src/builtin_widgets/border.rs
@@ -71,7 +71,7 @@ impl WrapRender for BorderWidget {
 
   fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
     let visual_box = host.visual_box(ctx);
-    let size = ctx.box_size().unwrap();
+    let size = ctx.box_size()?;
     if visual_box.is_none() {
       Some(Rect::from_size(size))
     } else {

--- a/core/src/builtin_widgets/clip_boundary.rs
+++ b/core/src/builtin_widgets/clip_boundary.rs
@@ -45,7 +45,7 @@ impl WrapRender for ClipBoundary {
   }
 
   fn visual_box(&self, _: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
-    let clip_rect = Rect::from_size(ctx.box_size().unwrap());
+    let clip_rect = Rect::from_size(ctx.box_size()?);
     ctx.clip(clip_rect);
     Some(clip_rect)
   }

--- a/core/src/builtin_widgets/fitted_box.rs
+++ b/core/src/builtin_widgets/fitted_box.rs
@@ -84,7 +84,7 @@ impl Render for FittedBox {
   }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    let clip_rect = Rect::from_size(ctx.box_size().unwrap());
+    let clip_rect = Rect::from_size(ctx.box_size()?);
     ctx.clip(clip_rect);
     Some(clip_rect)
   }

--- a/core/src/builtin_widgets/image_widget.rs
+++ b/core/src/builtin_widgets/image_widget.rs
@@ -17,7 +17,7 @@ impl Render for Resource<PixelImage> {
   }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    let box_rect = Rect::from_size(ctx.box_size().unwrap());
+    let box_rect = Rect::from_size(ctx.box_size()?);
     let img_rect = Rect::from_size(Size::new(self.width() as f32, self.height() as f32));
     img_rect.intersection(&box_rect)
   }

--- a/core/src/builtin_widgets/padding.rs
+++ b/core/src/builtin_widgets/padding.rs
@@ -53,7 +53,7 @@ impl WrapRender for Padding {
   fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
     host
       .visual_box(ctx)
-      .map_or(Some(Rect::from_size(ctx.box_size().unwrap())), |mut rect| {
+      .map_or(Some(Rect::from_size(ctx.box_size()?)), |mut rect| {
         rect.size += self.padding.thickness();
         Some(rect)
       })

--- a/core/src/builtin_widgets/svg.rs
+++ b/core/src/builtin_widgets/svg.rs
@@ -5,7 +5,7 @@ impl Render for Svg {
   fn perform_layout(&self, clamp: BoxClamp, _: &mut LayoutCtx) -> Size { clamp.clamp(self.size()) }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    Some(Rect::from_size(ctx.box_size().unwrap()))
+    Some(Rect::from_size(ctx.box_size()?))
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) {

--- a/core/src/builtin_widgets/transform_widget.rs
+++ b/core/src/builtin_widgets/transform_widget.rs
@@ -22,7 +22,7 @@ impl WrapRender for TransformWidget {
   fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
     host
       .visual_box(ctx)
-      .map_or(Some(Rect::from_size(ctx.box_size().unwrap())), |rect| {
+      .map_or(Some(Rect::from_size(ctx.box_size()?)), |rect| {
         Some(self.transform.outer_transformed_rect(&rect))
       })
   }

--- a/themes/material/src/state_layer.rs
+++ b/themes/material/src/state_layer.rs
@@ -87,7 +87,7 @@ impl<const M: u8> Render for StateLayer<M> {
   fn perform_layout(&self, clamp: BoxClamp, _: &mut LayoutCtx) -> Size { clamp.min }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    Some(Rect::from_size(ctx.box_size().unwrap()))
+    Some(Rect::from_size(ctx.box_size()?))
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) {

--- a/widgets/src/divider.rs
+++ b/widgets/src/divider.rs
@@ -79,7 +79,7 @@ impl Render for Divider {
   }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    let rect = self.paint_rect(ctx.box_size().unwrap());
+    let rect = self.paint_rect(ctx.box_size()?);
     Some(rect)
   }
 }

--- a/widgets/src/icon.rs
+++ b/widgets/src/icon.rs
@@ -118,7 +118,7 @@ impl Render for IconRender {
   }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    Some(Rect::from_size(ctx.box_size().unwrap()))
+    Some(Rect::from_size(ctx.box_size()?))
   }
 
   fn paint(&self, ctx: &mut PaintingCtx) {

--- a/widgets/src/input/text_glyphs.rs
+++ b/widgets/src/input/text_glyphs.rs
@@ -74,7 +74,7 @@ impl<T: VisualText + 'static> Render for TextGlyphs<T> {
   }
 
   fn visual_box(&self, _: &mut VisualCtx) -> Option<Rect> {
-    let visual_glyphs = self.glyphs().unwrap();
+    let visual_glyphs = self.glyphs()?;
     Some(visual_glyphs.visual_rect())
   }
 

--- a/widgets/src/progress.rs
+++ b/widgets/src/progress.rs
@@ -123,7 +123,7 @@ impl Render for SpinnerArc {
   }
 
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    let size = ctx.box_size().unwrap();
+    let size = ctx.box_size()?;
     Some(Rect::from_size(size))
   }
 

--- a/widgets/src/transform_box.rs
+++ b/widgets/src/transform_box.rs
@@ -29,7 +29,7 @@ impl Render for TransformBox {
 
   #[inline]
   fn visual_box(&self, ctx: &mut VisualCtx) -> Option<Rect> {
-    Some(Rect::from_size(ctx.box_size().unwrap()))
+    Some(Rect::from_size(ctx.box_size()?))
   }
 
   #[inline]


### PR DESCRIPTION
## Purpose of this Pull Request

Replace unwrap() with None checks when getting layout size.

Cases where layout size might be missing:
1. Called too early (before layout finishes)
2. Widgets under invisible parents (skipped in layout)

These cases could crash the app even when layout worked correctly.
## Checklist Before Merging

Please ensure the following are completed before merging:
- [ ] If this is linked to an issue, include the link in your description.
- [ ] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [ ] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.