### PR TITLE
feat(core): 🎸 add non-child field support to `Template`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 ### Features
 
 - **core**: Introduced the `PairOf` utility to preserve parent and child type information of `ComposeChild`. (#724 @M-Adoo)
-- **core**: Added `class_array!` macro to apply multiple classes at once. (#724 by @M-Adoo)·
+- **core**: Added `class_array!` macro to apply multiple classes at once. (#724 by @M-Adoo)
+- **core**: Add non-child field support to `Template`. (#725 @M-Adoo)
+  - Support default values for non-child fields via `#[template(field)]` attribute.
+  - Maintain backward compatibility with existing child-focused patterns
+
 
 ### Breaking
 

--- a/macros/src/simple_declare_attr.rs
+++ b/macros/src/simple_declare_attr.rs
@@ -5,6 +5,8 @@ use syn::{
   parse::{Parse, discouraged::Speculative},
   spanned::Spanned,
 };
+
+use crate::util;
 const DECLARE_ATTR: &str = "declare";
 
 pub struct Declarer<'a> {
@@ -243,13 +245,7 @@ impl<'a> DeclareField<'a> {
       .is_none_or(|attr| attr.custom.is_none() && attr.skip.is_none())
   }
 
-  pub fn doc_attr(&self) -> Option<&Attribute> {
-    self
-      .field
-      .attrs
-      .iter()
-      .find(|attr| matches!(&attr.meta, syn::Meta::NameValue(nv) if nv.path.is_ident("doc")))
-  }
+  pub fn doc_attr(&self) -> Option<&Attribute> { util::doc_attr(self.field) }
 }
 
 impl Parse for DeclareAttr {

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -15,3 +15,10 @@ pub fn data_struct_unwrap<'a>(
     }
   }
 }
+
+pub fn doc_attr(field: &syn::Field) -> Option<&syn::Attribute> {
+  field
+    .attrs
+    .iter()
+    .find(|attr| matches!(&attr.meta, syn::Meta::NameValue(nv) if nv.path.is_ident("doc")))
+}


### PR DESCRIPTION
## Purpose of this Pull Request

Added `#[template(field)]` to support declaring field syntax for `Template`.

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.