### PR TITLE
fix(core): 🐛 if pipe generate multi outer data of the first child is incorrectly wrapped to all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 - **core**: Fix `FittedBox` to always center its child (#727 by @M-Adoo)
 - **core**: Fix incorrect drop pointer press or release event when multiple devices are used simultaneously, ensuring that only the tap event is dropped while other events are fired correctly. (#730 @M-Adoo)
+- **core**: Fix the bug where the outer data of the first child is incorrectly wrapped around each child when the pipe dynamically generates multiple children. (#735 @wjian23)
 
 
 ### Changed

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -322,7 +322,7 @@ pub(crate) trait InnerPipe: Pipe + Sized {
           // We need to associate the parent information with the children pipe so that
           // when the child pipe is regenerated, it can update the parent pipe information
           // accordingly.
-          id.attach_data(Box::new(pipe_node), tree);
+          id.attach_data(Box::new(QueryFilter::only_self(pipe_node)), tree);
         }
       });
 


### PR DESCRIPTION
## Purpose of this Pull Request

if pipe generate multi outer data of the first child is incorrectly wrapped to all

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.