### PR TITLE
fix(ribir): 🐛 ribir run app with default theme of material light

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ thiserror = "2.0.12"
 wasm-bindgen-futures = "0.4.50"
 getrandom-v2 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom-v3 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
-cfg-if = "1.0.1"
+cfg-if = "1.0"
 
 
 [workspace.metadata.release]

--- a/ribir/Cargo.toml
+++ b/ribir/Cargo.toml
@@ -23,6 +23,7 @@ wgpu = { workspace = true, optional = true }
 winit.workspace = true
 futures.workspace = true
 pin-project-lite.workspace = true
+cfg-if.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 arboard.workspace = true

--- a/ribir/src/app.rs
+++ b/ribir/src/app.rs
@@ -338,7 +338,17 @@ impl AppRunGuard {
     assert!(!ONCE.is_completed(), "App::run can only be called once.");
     ONCE.call_once(|| {});
 
-    Self { root: Some(Box::new(root)), wnd_attrs: Some(WindowAttributes::default()), theme: None }
+    let theme: Option<Box<dyn FnOnce() -> Theme + Send + 'static>> = {
+      cfg_if::cfg_if! {
+        if #[cfg(feature = "ribir_material")] {
+          Some(Box::new(ribir_material::purple::light))
+        } else {
+          None
+        }
+      }
+    };
+
+    Self { root: Some(Box::new(root)), wnd_attrs: Some(WindowAttributes::default()), theme }
   }
 
   /// Set the application theme, this will apply to whole application.


### PR DESCRIPTION
## Purpose of this Pull Request

fix bug: ribir run app with default theme of material light

## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.