### PR TITLE
fix: fix all unstable let expression syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Please only add new entries below the [Unreleased](#unreleased---releasedate) he
 
 ## [@Unreleased] - @ReleaseDate
 
+### Fixed
+
+- **all**: Replace all unstable 'if let ... && let ...' syntax with stable nested 'if let' structures, fixing 40 compilation errors to allow the code to compile on stable Rust. (#pr @vnxfsc)
+
 ## [0.4.0-alpha.49] - 2025-09-03
 
 ## [0.4.0-alpha.48] - 2025-08-27

--- a/core/src/animation/animate.rs
+++ b/core/src/animation/animate.rs
@@ -127,11 +127,11 @@ where
 
   fn stop(&self) {
     let mut this = self.silent();
-    if this.is_running()
-      && let Some(wnd) = AppCtx::get_window(this.window_id)
-    {
-      wnd.dec_running_animate();
-      this.running_info.take();
+    if this.is_running() {
+      if let Some(wnd) = AppCtx::get_window(this.window_id) {
+        wnd.dec_running_animate();
+        this.running_info.take();
+      }
     }
   }
 
@@ -182,10 +182,10 @@ where
   P: AnimateState,
 {
   fn drop(&mut self) {
-    if self.running_info.is_some()
-      && let Some(wnd) = AppCtx::get_window(self.window_id)
-    {
-      wnd.dec_running_animate();
+    if self.running_info.is_some() {
+      if let Some(wnd) = AppCtx::get_window(self.window_id) {
+        wnd.dec_running_animate();
+      }
     }
   }
 }

--- a/core/src/builtin_widgets/mix_builtin.rs
+++ b/core/src/builtin_widgets/mix_builtin.rs
@@ -526,10 +526,10 @@ impl FocusHandle {
   pub fn set_tab_index(&mut self, tab_idx: i16) { self.flags.write().set_tab_index(tab_idx); }
 
   pub fn request_focus(&self, reason: FocusReason) {
-    if let Some(wnd) = AppCtx::get_window(self.wnd)
-      && let Some(wid) = self.host.get()
-    {
-      wnd.focus_mgr.borrow_mut().focus(wid, reason);
+    if let Some(wnd) = AppCtx::get_window(self.wnd) {
+      if let Some(wid) = self.host.get() {
+        wnd.focus_mgr.borrow_mut().focus(wid, reason);
+      }
     }
   }
 

--- a/core/src/builtin_widgets/providers.rs
+++ b/core/src/builtin_widgets/providers.rs
@@ -618,10 +618,10 @@ impl ProviderCtx {
     let mut out = Vec::new();
     let keys = self.data.keys().cloned().collect::<Vec<_>>();
     for k in keys {
-      if f(&k)
-        && let Some(v) = self.data.remove(&k)
-      {
-        out.push((k, v));
+      if f(&k) {
+        if let Some(v) = self.data.remove(&k) {
+          out.push((k, v));
+        }
       }
     }
     out

--- a/core/src/builtin_widgets/tooltips.rs
+++ b/core/src/builtin_widgets/tooltips.rs
@@ -32,18 +32,18 @@ impl Declare for Tooltips {
 
 impl Tooltips {
   pub fn show(&self, wnd: Sc<Window>) {
-    if let Some(overlay) = self.overlay.borrow().clone()
-      && !overlay.is_showing()
-    {
-      overlay.show(wnd);
+    if let Some(overlay) = self.overlay.borrow().clone() {
+      if !overlay.is_showing() {
+        overlay.show(wnd);
+      }
     }
   }
 
   pub fn hidden(&self) {
-    if let Some(overlay) = self.overlay.borrow().clone()
-      && overlay.is_showing()
-    {
-      overlay.close();
+    if let Some(overlay) = self.overlay.borrow().clone() {
+      if overlay.is_showing() {
+        overlay.close();
+      }
     }
   }
 }

--- a/core/src/events/dispatcher.rs
+++ b/core/src/events/dispatcher.rs
@@ -185,10 +185,10 @@ impl Dispatcher {
     } else {
       if let Some(hit) = hit {
         wnd.add_delay_event(DelayEvent::PointerUp(hit));
-        if let Some(wid) = self.pointer_down_wid
-          && let Some(p) = wid.lowest_common_ancestor(hit, wnd.tree())
-        {
-          wnd.add_delay_event(DelayEvent::Tap(p));
+        if let Some(wid) = self.pointer_down_wid {
+          if let Some(p) = wid.lowest_common_ancestor(hit, wnd.tree()) {
+            wnd.add_delay_event(DelayEvent::Tap(p));
+          }
         }
       }
       self.pointer_down_wid = None;
@@ -242,12 +242,12 @@ impl Dispatcher {
           hit_target = Some(id);
         }
 
-        if (hit || can_hit_child)
-          && let Some(c) = id.last_child(tree)
-        {
-          *pos = ctx.map_from_parent(*pos);
-          ctx.set_id(c);
-          continue;
+        if hit || can_hit_child {
+          if let Some(c) = id.last_child(tree) {
+            *pos = ctx.map_from_parent(*pos);
+            ctx.set_id(c);
+            continue;
+          }
         }
 
         break;

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -171,21 +171,21 @@ impl Overlay {
     let track_id = self.0.borrow_mut().track_id.take();
     if let Some(showing) = showing {
       let ShowingInfo { wnd_id, .. } = showing;
-      if let Some(wnd) = AppCtx::get_window(wnd_id)
-        && let Some(wid) = track_id.and_then(|track_id| track_id.get())
-      {
-        let this = self.clone();
-        AppCtx::spawn_local(async move {
-          {
-            let _guard = BuildCtx::init_for(wnd.tree().root(), wnd.tree);
-            let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
-            showing_overlays.remove(&this);
-          }
-          let tree = wnd.tree_mut();
-          let root = tree.root();
-          wid.dispose_subtree(tree);
-          tree.dirty_marker().mark(root, DirtyPhase::Layout);
-        });
+      if let Some(wnd) = AppCtx::get_window(wnd_id) {
+        if let Some(wid) = track_id.and_then(|track_id| track_id.get()) {
+          let this = self.clone();
+          AppCtx::spawn_local(async move {
+            {
+              let _guard = BuildCtx::init_for(wnd.tree().root(), wnd.tree);
+              let showing_overlays = Provider::of::<ShowingOverlays>(BuildCtx::get()).unwrap();
+              showing_overlays.remove(&this);
+            }
+            let tree = wnd.tree_mut();
+            let root = tree.root();
+            wid.dispose_subtree(tree);
+            tree.dirty_marker().mark(root, DirtyPhase::Layout);
+          });
+        }
       }
     }
   }
@@ -203,10 +203,10 @@ impl Overlay {
         }
         if close_policy.contains(AutoClosePolicy::TAP_OUTSIDE) {
           container.on_tap(move |e| {
-            if e.target() == e.current_target()
-              && let Some(overlay) = Overlay::of(&**e)
-            {
+            if e.target() == e.current_target() {
+              if let Some(overlay) = Overlay::of(&**e) {
                 overlay.close();
+              }
             }
           });
         }
@@ -216,10 +216,10 @@ impl Overlay {
       };
       if close_policy.contains(AutoClosePolicy::ESC) {
         w.on_key_down(move |e| {
-          if *e.key() == VirtualKey::Named(NamedKey::Escape) &&
-            let Some(overlay) = Overlay::of(&**e)
-          {
-            overlay.close();
+          if *e.key() == VirtualKey::Named(NamedKey::Escape) {
+            if let Some(overlay) = Overlay::of(&**e) {
+              overlay.close();
+            }
           }
         });
       }

--- a/core/src/widget_tree.rs
+++ b/core/src/widget_tree.rs
@@ -107,11 +107,11 @@ impl WidgetTree {
           let visual_rect = ctx.visual_box(wid);
           ctx.perform_layout(clamp);
           let new_rect = ctx.visual_box(wid);
-          if visual_rect != new_rect
-            && let Some(parent) = wid.parent(self)
-          {
-            let depth = parent.ancestors(self).count();
-            visual_roots.insert((depth, parent));
+          if visual_rect != new_rect {
+            if let Some(parent) = wid.parent(self) {
+              let depth = parent.ancestors(self).count();
+              visual_roots.insert((depth, parent));
+            }
           }
         }
       }
@@ -128,10 +128,10 @@ impl WidgetTree {
         let mut ctx = LayoutCtx::new(wid, self, laid_out_queue);
         let visual_rect = ctx.visual_box(wid);
         let new_rect = ctx.update_visual_box();
-        if visual_rect != new_rect
-          && let Some(parent) = wid.parent(self)
-        {
-          visual_roots.insert((depth - 1, parent));
+        if visual_rect != new_rect {
+          if let Some(parent) = wid.parent(self) {
+            visual_roots.insert((depth - 1, parent));
+          }
         }
       }
     }

--- a/core/src/widget_tree/widget_id.rs
+++ b/core/src/widget_tree/widget_id.rs
@@ -281,10 +281,17 @@ impl WidgetId {
     let mut painting = vec![];
     loop {
       let id = ctx.id();
-      if !ctx.painter().is_transparent()
-        && let Some(layout_box) = ctx.box_rect()
-      {
-        painting.push(id);
+      let layout_box = if !ctx.painter().is_transparent() {
+        if let Some(layout_box) = ctx.box_rect() {
+          painting.push(id);
+          Some(layout_box)
+        } else {
+          None
+        }
+      } else {
+        None
+      };
+      if let Some(layout_box) = layout_box {
         let render = id.assert_get(tree);
         ctx
           .painter()

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -697,11 +697,12 @@ impl Window {
             ElementState::Released => Event::KeyUp(event),
           };
           self.bottom_up_emit(&mut event, None);
-          if let Event::KeyDown(e) = event
-            && !e.is_prevent_default()
-            && *e.key() == VirtualKey::Named(NamedKey::Tab)
-          {
-            self.add_delay_event(DelayEvent::TabFocusMove);
+          if let Event::KeyDown(e) = event {
+            if !e.is_prevent_default()
+              && *e.key() == VirtualKey::Named(NamedKey::Tab)
+            {
+              self.add_delay_event(DelayEvent::TabFocusMove);
+            }
           }
         }
         DelayEvent::TabFocusMove => {

--- a/painter/src/svg.rs
+++ b/painter/src/svg.rs
@@ -265,12 +265,12 @@ fn fallback_color_check(cmds: &[PaintCommand]) -> (bool, bool) {
 
     match c {
       PaintCommand::Path(p) => {
-        if let PaintPathAction::Paint { painting_style, brush, .. } = &p.action
-          && matches!(brush, CommandBrush::Color(c) if c == &Svg::DYNAMIC_COLOR)
-        {
-          match painting_style {
-            crate::PaintingStyle::Fill => fill_fallback = true,
-            crate::PaintingStyle::Stroke(_) => stroke_fallback = true,
+        if let PaintPathAction::Paint { painting_style, brush, .. } = &p.action {
+          if matches!(brush, CommandBrush::Color(c) if c == &Svg::DYNAMIC_COLOR) {
+            match painting_style {
+              crate::PaintingStyle::Fill => fill_fallback = true,
+              crate::PaintingStyle::Stroke(_) => stroke_fallback = true,
+            }
           }
         }
       }
@@ -292,12 +292,12 @@ fn brush_replace(cmds: &[PaintCommand], fill: &Brush, stroke: &Brush) -> Box<[Pa
     .map(|c| match c {
       PaintCommand::Path(p) => {
         let mut p = p.clone();
-        if let PaintPathAction::Paint { painting_style, brush, .. } = &mut p.action
-          && matches!(brush, CommandBrush::Color(c) if c == &Svg::DYNAMIC_COLOR)
-        {
-          match painting_style {
-            crate::PaintingStyle::Fill => *brush = fill.clone().into(),
-            crate::PaintingStyle::Stroke(_) => *brush = stroke.clone().into(),
+        if let PaintPathAction::Paint { painting_style, brush, .. } = &mut p.action {
+          if matches!(brush, CommandBrush::Color(c) if c == &Svg::DYNAMIC_COLOR) {
+            match painting_style {
+              crate::PaintingStyle::Fill => *brush = fill.clone().into(),
+              crate::PaintingStyle::Stroke(_) => *brush = stroke.clone().into(),
+            }
           }
         }
         PaintCommand::Path(p)
@@ -335,16 +335,16 @@ fn convert_to_gradient_stops(stops: &[Stop]) -> Vec<GradientStop> {
 
   stops.sort_by(|s1, s2| s1.offset.partial_cmp(&s2.offset).unwrap());
 
-  if let Some(first) = stops.first()
-    && first.offset != 0.
-  {
-    stops.insert(0, GradientStop { offset: 0., color: first.color });
+  if let Some(first) = stops.first() {
+    if first.offset != 0. {
+      stops.insert(0, GradientStop { offset: 0., color: first.color });
+    }
   }
 
-  if let Some(last) = stops.last()
-    && last.offset < 1.
-  {
-    stops.push(GradientStop { offset: 1., color: last.color });
+  if let Some(last) = stops.last() {
+    if last.offset < 1. {
+      stops.push(GradientStop { offset: 1., color: last.color });
+    }
   }
   stops
 }

--- a/painter/src/text/shaper.rs
+++ b/painter/src/text/shaper.rs
@@ -60,11 +60,12 @@ impl TextShaper {
         .shape_text_with_fallback(text, direction, face_ids, baseline)
         .unwrap_or_default();
 
-      if let Some(last_char) = text.bytes().last()
-        && (last_char == b'\r' || last_char == b'\n')
-        && let Some(g) = glyphs.last_mut()
-      {
-        g.glyph_id = NEWLINE_GLYPH_ID;
+      if let Some(last_char) = text.bytes().last() {
+        if last_char == b'\r' || last_char == b'\n' {
+          if let Some(g) = glyphs.last_mut() {
+            g.glyph_id = NEWLINE_GLYPH_ID;
+          }
+        }
       }
 
       let glyphs = Sc::new(ShapeResult { text: text.clone(), glyphs });

--- a/ribir/src/app/app_event_handler.rs
+++ b/ribir/src/app/app_event_handler.rs
@@ -70,10 +70,10 @@ impl ApplicationHandler<RibirAppEvent> for AppHandler {
           is_repeat: event.repeat,
           location: event.location,
         });
-        if event.state == ElementState::Pressed
-          && let Some(txt) = event.text
-        {
-          App::send_event(UiEvent::ReceiveChars { wnd_id, chars: txt.to_string().into() });
+        if event.state == ElementState::Pressed {
+          if let Some(txt) = event.text {
+            App::send_event(UiEvent::ReceiveChars { wnd_id, chars: txt.to_string().into() });
+          }
         }
       }
       WindowEvent::Ime(ime) => {

--- a/ribir/src/winit_shell_wnd.rs
+++ b/ribir/src/winit_shell_wnd.rs
@@ -210,10 +210,10 @@ impl ShellWindow for ShellWndHandle {
       .winit_wnd
       .request_inner_size(LogicalSize::new(size.width, size.height))
       .map(|size| Size::new(size.width as f32, size.height as f32));
-    if size.is_some()
-      && let Some(wnd) = AppCtx::get_window(self.id())
-    {
-      wnd.shell_wnd().borrow().request_draw();
+    if size.is_some() {
+      if let Some(wnd) = AppCtx::get_window(self.id()) {
+        wnd.shell_wnd().borrow().request_draw();
+      }
     }
   }
 

--- a/themes/material/src/state_layer.rs
+++ b/themes/material/src/state_layer.rs
@@ -132,14 +132,14 @@ impl<const M: u8> WrapRender for StateLayer<M> {
   }
 
   fn visual_box(&self, host: &dyn Render, ctx: &mut VisualCtx) -> Option<Rect> {
-    if let LayerArea::Circle { radius, .. } = self.area
-      && self.draw_opacity > 0.
-    {
-      let rect = Rect::from_size(Size::splat(radius * 2.));
-      let union = host
-        .visual_box(ctx)
-        .map_or(rect, |v| v.union(&rect));
-      return Some(union);
+    if let LayerArea::Circle { radius, .. } = self.area {
+      if self.draw_opacity > 0. {
+        let rect = Rect::from_size(Size::splat(radius * 2.));
+        let union = host
+          .visual_box(ctx)
+          .map_or(rect, |v| v.union(&rect));
+        return Some(union);
+      }
     }
 
     host.visual_box(ctx)

--- a/widgets/src/input/text_editable.rs
+++ b/widgets/src/input/text_editable.rs
@@ -72,12 +72,12 @@ impl<T: EditText + 'static> BasicEditor<T> {
         class: TEXT_CARET,
         on_performed_layout: move |e| {
           let caret_size = e.box_size().unwrap();
-          if !$read(this).is_in_pre_edit()
-            && let Some(mut scrollable) = Provider::write_of::<ScrollableWidget>(e)
-          {
-            let wnd = e.window();
-            let lt = scrollable.map_to_content(Point::zero(), e.current_target(), &wnd).unwrap();
-            scrollable.visible_content_box(Rect::new(lt, caret_size), Anchor::default());
+          if !$read(this).is_in_pre_edit() {
+            if let Some(mut scrollable) = Provider::write_of::<ScrollableWidget>(e) {
+              let wnd = e.window();
+              let lt = scrollable.map_to_content(Point::zero(), e.current_target(), &wnd).unwrap();
+              scrollable.visible_content_box(Rect::new(lt, caret_size), Anchor::default());
+            }
           }
           let pos = e.map_to_global(Point::zero());
           e.window().set_ime_cursor_area(&Rect::new(pos, caret_size));

--- a/widgets/src/menu.rs
+++ b/widgets/src/menu.rs
@@ -330,10 +330,11 @@ impl MenuControl {
       .items
       .iter()
       .position(|item| item.label == label)
-      && let Some(wid) = this.items[idx].wid.get()
     {
-      wnd
-        .bubble_custom_event(wid, MenuEventData::Complete { idx, label, menu: self.clone(), data });
+      if let Some(wid) = this.items[idx].wid.get() {
+        wnd
+          .bubble_custom_event(wid, MenuEventData::Complete { idx, label, menu: self.clone(), data });
+      }
     }
   }
 }
@@ -432,10 +433,10 @@ impl<'w> MenuItem<'w> {
         on_disposed: {
           let sub_menu = sub_menu.clone();
           move |e| {
-            if let Some(menu) = sub_menu.as_ref()
-              && menu.is_show()
-            {
-              menu.close(&e.window());
+            if let Some(menu) = sub_menu.as_ref() {
+              if menu.is_show() {
+                menu.close(&e.window());
+              }
             }
           }
         },
@@ -447,19 +448,19 @@ impl<'w> MenuItem<'w> {
                 *$write(class) = MENU_ITEM_SELECTED;
               } else {
                 *$write(class) = MENU_ITEM;
-                if let Some(menu) = sub_menu.as_ref() &&
-                  menu.is_show()
-                {
-                  menu.close(&wnd);
+                if let Some(menu) = sub_menu.as_ref() {
+                  if menu.is_show() {
+                    menu.close(&wnd);
+                  }
                 }
               }
             },
             MenuEventData::Enter{ idx, menu, .. } => {
-              if let Some(sub_menu) = sub_menu.as_ref()
-                && !sub_menu.is_show()
-              {
-                let id = e.current_target();
-                menu.show_sub_menu(*idx, sub_menu, id, &wnd);
+              if let Some(sub_menu) = sub_menu.as_ref() {
+                if !sub_menu.is_show() {
+                  let id = e.current_target();
+                  menu.show_sub_menu(*idx, sub_menu, id, &wnd);
+                }
               }
             },
             _ => (),

--- a/widgets/src/router.rs
+++ b/widgets/src/router.rs
@@ -127,10 +127,10 @@ impl Router {
   /// - Injects matched parameters into widget context
   /// - Returns void widget when no routes match
   fn switch(&self, ctx: &BuildCtx) -> Widget<'static> {
-    if let Some(route_params) = Provider::of::<RouterParams>(ctx)
-      && let Some(path) = route_params.get_param("*")
-    {
-      return self.switch_to(path);
+    if let Some(route_params) = Provider::of::<RouterParams>(ctx) {
+      if let Some(path) = route_params.get_param("*") {
+        return self.switch_to(path);
+      }
     }
 
     self.switch_to(Location::of(ctx).path())

--- a/widgets/src/select_region.rs
+++ b/widgets/src/select_region.rs
@@ -57,14 +57,14 @@ impl<'c> ComposeChild<'c> for PointerSelectRegion {
         },
         on_pointer_up: move |e| {
           let from = $write(from).take();
-          if $write(grab_handle).take().is_some()
-            && let Some(from) = from
-          {
-            notify_select_changed(
-              e.current_target(),
-              PointerSelectData::End{ from, to: e.position() },
-              &e.window()
-            );
+          if $write(grab_handle).take().is_some() {
+            if let Some(from) = from {
+              notify_select_changed(
+                e.current_target(),
+                PointerSelectData::End{ from, to: e.position() },
+                &e.window()
+              );
+            }
           }
         },
       }

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -51,10 +51,10 @@ pub struct Slider {
 impl Slider {
   fn set_to(&mut self, mut v: f32) {
     v = v.clamp(0., 1.);
-    if let Some(divisions) = self.divisions
-      && divisions > 0
-    {
-      v = (v * divisions as f32).round() / (divisions as f32);
+    if let Some(divisions) = self.divisions {
+      if divisions > 0 {
+        v = (v * divisions as f32).round() / (divisions as f32);
+      }
     }
 
     self.value = (self.min + v * (self.max - self.min)).clamp(self.min, self.max);
@@ -66,10 +66,10 @@ impl Slider {
     }
     let mut v = (self.value - self.min) / (self.max - self.min);
     v = v.clamp(0., 1.);
-    if let Some(divisions) = self.divisions
-      && divisions > 0
-    {
-      v = (v * divisions as f32).round() / (divisions as f32)
+    if let Some(divisions) = self.divisions {
+      if divisions > 0 {
+        v = (v * divisions as f32).round() / (divisions as f32)
+      }
     }
     v
   }
@@ -213,10 +213,10 @@ impl RangeSlider {
   }
 
   fn convert_ratio(&self, mut ratio: f32) -> f32 {
-    if let Some(divisions) = self.divisions
-      && divisions > 1
-    {
-      ratio = (ratio * divisions as f32).round() / (divisions as f32);
+    if let Some(divisions) = self.divisions {
+      if divisions > 1 {
+        ratio = (ratio * divisions as f32).round() / (divisions as f32);
+      }
     }
     self.min + ratio * (self.max - self.min)
   }
@@ -227,10 +227,10 @@ impl RangeSlider {
     }
     let mut v = (v - self.min) / (self.max - self.min);
     v = v.clamp(0., 1.);
-    if let Some(divisions) = self.divisions
-      && divisions > 0
-    {
-      v = (v * divisions as f32).round() / (divisions as f32);
+    if let Some(divisions) = self.divisions {
+      if divisions > 0 {
+        v = (v * divisions as f32).round() / (divisions as f32);
+      }
     }
     v
   }


### PR DESCRIPTION
Replace all unstable 'if let ... && let ...' syntax with stable nested 'if let' structures.

Fixed 40 compilation errors across the following packages:
- ribir_painter: 6 fixes
- ribir_core: 18 fixes
- ribir_widgets: 13 fixes
- ribir_material: 1 fix
- ribir: 2 fixes

These fixes allow the code to compile on stable Rust.
