### PR TITLE
refactor(deps):💡 upgrade rxrust to stable-1.0 and adapt APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ proc-macro2 = "1.0.101"
 quote = "1.0.37"
 rayon = "1.10.0"
 rustybuzz = "0.20.1"
-rxrust = { version = "1.0.0-beta.10", default-features = false, features = [] }
+rxrust = "1.0.0-rc.0"
 scoped_threadpool = "0.1.9"
 triomphe = "0.1.12"
 serde = "1.0"
@@ -87,9 +87,9 @@ zerocopy = "0.7.3"
 quick-xml = "0.38.4"
 macos-accessibility-client = { version = "0.0.1" }
 tokio = { version = "1.0" }
+
 priority-queue = "2.1.1"
 web-sys = { version = "0.3.69", features = ["HtmlCollection"] }
-web-time = "1.1.0"
 heck = "0.5.0"
 url = "2.5.4"
 thiserror = "2.0.12"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "rt", "time", "macros
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { workspace = true, features = ["Location", "Window", "History"]}
-web-time.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "macros"]}
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 wasm-bindgen-futures.workspace = true

--- a/core/src/animation/animate.rs
+++ b/core/src/animation/animate.rs
@@ -99,6 +99,9 @@ where
       let state_handle = this
         .state
         .animate_state_modifies()
+        // State transition may trigger an animation run during a state modification, causing borrow
+        // conflicts. To avoid this, delay the run until the next tick.
+        .delay_subscription(Duration::ZERO)
         .subscribe(move |_| {
           let mut animate = animate.write();
           let v = animate.state.get();

--- a/core/src/animation/stagger.rs
+++ b/core/src/animation/stagger.rs
@@ -56,7 +56,7 @@ use crate::prelude::*;
 pub struct Stagger {
   stagger: std::time::Duration,
   transition: Box<dyn Transition>,
-  running_handle: Option<TaskHandle<NormalReturn<()>>>,
+  running_handle: Option<TaskHandle>,
   next_to_run: Option<AnimationCursor>,
   animations: Vec<(std::time::Duration, Box<dyn Animation>)>,
   run_times: usize,
@@ -188,7 +188,7 @@ impl Stateful<Stagger> {
         drop(this);
 
         let this = self.clone_writer();
-        let h = observable::timer_at((), at, AppCtx::scheduler()).subscribe(move |_| {
+        let h = Local::timer_at(at).subscribe(move |_| {
           next.run();
           this.trigger_next();
         });

--- a/core/src/builtin_widgets.rs
+++ b/core/src/builtin_widgets.rs
@@ -1428,11 +1428,11 @@ impl<T> std::ops::DerefMut for FatObj<T> {
 /// of unsubscribing when disposed.
 pub struct DeclarerWithSubscription<T> {
   inner: T,
-  subscribes: SmallVec<[BoxSubscription<'static>; 1]>,
+  subscribes: SmallVec<[BoxedSubscription; 1]>,
 }
 
 impl<T> DeclarerWithSubscription<T> {
-  pub fn new(host: T, subscribes: SmallVec<[BoxSubscription<'static>; 1]>) -> Self {
+  pub fn new(host: T, subscribes: SmallVec<[BoxedSubscription; 1]>) -> Self {
     Self { inner: host, subscribes }
   }
 

--- a/core/src/builtin_widgets/class.rs
+++ b/core/src/builtin_widgets/class.rs
@@ -342,7 +342,7 @@ impl<'c> ComposeChild<'c> for Class {
         let u = this2
           .raw_modifies()
           .filter(|s| s.contains(ModifyEffect::FRAMEWORK))
-          .merge(observable::of(ModifyInfo::default()))
+          .merge(Local::of(ModifyInfo::default()))
           .map(move |_| this2.read().clone())
           .distinct_until_changed()
           .skip(1)

--- a/core/src/builtin_widgets/global_anchor.rs
+++ b/core/src/builtin_widgets/global_anchor.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use ops::box_it::BoxOp;
+use rxrust::{observable::boxed::LocalBoxedObservable, subscription::BoxedSubscription};
 
 use crate::{prelude::*, ticker::FrameMsg};
 
@@ -84,7 +84,7 @@ pub struct GlobalAnchor {
   /// the vertical global anchor
   pub global_anchor_y: Option<GlobalAnchorY>,
 
-  guard: RefCell<Option<SubscriptionGuard<BoxSubscription<'static>>>>,
+  guard: RefCell<Option<SubscriptionGuard<BoxedSubscription>>>,
 }
 
 impl GlobalAnchorX {
@@ -308,7 +308,7 @@ fn apply_global_anchor(
   let anchor_x = this_ref.global_anchor_x.as_ref();
   let anchor_y = this_ref.global_anchor_y.as_ref();
 
-  let watch: BoxOp<'static, _, _> =
+  let watch: LocalBoxedObservable<'static, _, _> =
     match (anchor_x.is_some_and(|x| x.is_once()), anchor_y.is_some_and(|y| y.is_once())) {
       (true, true) => tick_of_layout_ready.take(1).box_it(),
       _ => tick_of_layout_ready.box_it(),

--- a/core/src/builtin_widgets/providers.rs
+++ b/core/src/builtin_widgets/providers.rs
@@ -145,7 +145,7 @@
 //! ```
 use std::{cell::RefCell, convert::Infallible};
 
-use ops::box_it::CloneableBoxOp;
+use rxrust::observable::boxed::LocalBoxedObservableClone;
 use smallvec::SmallVec;
 use widget_id::RenderQueryable;
 
@@ -759,14 +759,14 @@ struct Restore {
 struct WriterSetup {
   info: TypeInfo,
   value: Box<dyn Query>,
-  modifies: CloneableBoxOp<'static, ModifyInfo, Infallible>,
+  modifies: LocalBoxedObservableClone<'static, ModifyInfo, Infallible>,
   dirty: DirtyPhase,
 }
 
 struct WriterRestore {
   info: TypeInfo,
   restore_value: Option<Box<dyn Query>>,
-  modifies: CloneableBoxOp<'static, ModifyInfo, Infallible>,
+  modifies: LocalBoxedObservableClone<'static, ModifyInfo, Infallible>,
   dirty: DirtyPhase,
 }
 
@@ -977,8 +977,7 @@ mod tests {
       providers: [Provider::new(w_value.clone_writer())],
       @ {
         // We do not allow the use of the build context in the pipe at the moment.
-        let value = Provider::of::<Stateful<i32>>(BuildCtx::get())
-          .unwrap().clone_writer();
+        let value = Provider::of::<Stateful<i32>>(BuildCtx::get()).unwrap();
         pipe!(*$read(trigger)).map(move |_| {
           *$write(value) += 1;
           @Void {}

--- a/core/src/builtin_widgets/tooltips.rs
+++ b/core/src/builtin_widgets/tooltips.rs
@@ -74,7 +74,7 @@ impl<'c> ComposeChild<'c> for Tooltips {
     fn_widget! {
       let wnd = BuildCtx::get().window();
       let u = watch!(*$read(child.is_hovered()))
-        .delay(Duration::from_millis(50), AppCtx::scheduler())
+        .delay(Duration::from_millis(50))
         .distinct_until_changed()
         .subscribe(move |_| {
           if *$read(child.is_hovered()) {

--- a/core/src/declare.rs
+++ b/core/src/declare.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use rxrust::ops::box_it::BoxOp;
+use rxrust::observable::boxed::LocalBoxedObservable;
 
 use crate::prelude::*;
 
@@ -25,7 +25,7 @@ pub enum PipeValue<V> {
   Pipe { init_value: V, pipe: Pipe<V> },
 }
 
-pub type ValueStream<V> = BoxOp<'static, V, Infallible>;
+pub type ValueStream<V> = LocalBoxedObservable<'static, V, Infallible>;
 
 impl<V: 'static> PipeValue<V> {
   pub fn unzip(self) -> (V, Option<ValueStream<V>>) {

--- a/core/src/event_loop.rs
+++ b/core/src/event_loop.rs
@@ -192,7 +192,6 @@ impl FrameHandle {
     }
     let mut ticker = self.wnd.frame_ticker.clone();
     ticker.next(FrameMsg::Finish(Instant::now()));
-    ticker.retain();
   }
 
   fn frame_end(self) -> (Vec<RibirEvent>, EventLoopHandle) {

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -7,7 +7,7 @@ pub mod state_cell;
 
 pub use part_state::*;
 pub use prior_op::*;
-use rxrust::ops::box_it::{BoxOp, CloneableBoxOp};
+use rxrust::observable::boxed::LocalBoxedObservableClone;
 use smallvec::SmallVec;
 pub use state_cell::*;
 pub use stateful::*;
@@ -81,16 +81,16 @@ pub trait StateWatcher: StateReader {
 
   /// Return a modifies `Rx` stream of the state, user can subscribe it to
   /// response the state changes.
-  fn modifies(&self) -> BoxOp<'static, ModifyInfo, Infallible> {
+  fn modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible> {
     self
       .raw_modifies()
       .filter(|s| s.contains(ModifyEffect::DATA))
-      .box_it()
+      .box_it_clone()
   }
 
   /// Return a modifies `Rx` stream of the state, including all modifies. Use
   /// `modifies` instead if you only want to response the data changes.
-  fn raw_modifies(&self) -> CloneableBoxOp<'static, ModifyInfo, Infallible>;
+  fn raw_modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible>;
 
   /// Clone a boxed watcher that can be used to observe the modifies of the
   /// state.
@@ -362,7 +362,7 @@ impl<V: ?Sized + 'static> StateWatcher for Box<dyn StateWatcher<Value = V>> {
   fn into_reader(self) -> Result<Self::Reader, Self> { Err(self) }
 
   #[inline]
-  fn raw_modifies(&self) -> CloneableBoxOp<'static, ModifyInfo, Infallible> {
+  fn raw_modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible> {
     (**self).raw_modifies()
   }
 
@@ -398,7 +398,7 @@ impl<V: ?Sized + 'static> StateWatcher for Box<dyn StateWriter<Value = V>> {
   fn into_reader(self) -> Result<Self::Reader, Self> { Err(self) }
 
   #[inline]
-  fn raw_modifies(&self) -> CloneableBoxOp<'static, ModifyInfo, Infallible> {
+  fn raw_modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible> {
     (**self).raw_modifies()
   }
 

--- a/core/src/state/part_state.rs
+++ b/core/src/state/part_state.rs
@@ -86,7 +86,7 @@ where
     Box::new(self.clone_watcher())
   }
 
-  fn raw_modifies(&self) -> CloneableBoxOp<'static, ModifyInfo, Infallible> {
+  fn raw_modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible> {
     let modifies = self
       .write()
       .notify_guard
@@ -101,7 +101,7 @@ where
         .filter(move |info| {
           info.path.starts_with(&path) && (include_partial || info.path.len() == path.len())
         })
-        .box_it()
+        .box_it_clone()
     } else {
       modifies
     }

--- a/core/src/state/watcher.rs
+++ b/core/src/state/watcher.rs
@@ -1,17 +1,17 @@
 use std::convert::Infallible;
 
-use rxrust::ops::box_it::CloneableBoxOp;
+use rxrust::observable::boxed::LocalBoxedObservableClone;
 
 use crate::prelude::*;
 
 pub struct Watcher<R> {
   reader: R,
-  modifies_observable: CloneableBoxOp<'static, ModifyInfo, Infallible>,
+  modifies_observable: LocalBoxedObservableClone<'static, ModifyInfo, Infallible>,
 }
 
 impl<R> Watcher<R> {
   pub fn new(
-    reader: R, modifies_observable: CloneableBoxOp<'static, ModifyInfo, Infallible>,
+    reader: R, modifies_observable: LocalBoxedObservableClone<'static, ModifyInfo, Infallible>,
   ) -> Self {
     Self { reader, modifies_observable }
   }
@@ -59,7 +59,7 @@ impl<R: StateReader> StateWatcher for Watcher<R> {
   }
 
   #[inline]
-  fn raw_modifies(&self) -> CloneableBoxOp<'static, ModifyInfo, Infallible> {
+  fn raw_modifies(&self) -> LocalBoxedObservableClone<'static, ModifyInfo, Infallible> {
     self.modifies_observable.clone()
   }
 

--- a/core/src/ticker.rs
+++ b/core/src/ticker.rs
@@ -1,13 +1,10 @@
 use std::convert::Infallible;
-#[cfg(not(target_arch = "wasm32"))]
-pub use std::time::{Duration, Instant};
 
-use rxrust::prelude::Subject;
-#[cfg(target_arch = "wasm32")]
-pub use web_time::{Duration, Instant};
+use rxrust::subject::LocalSubject;
+pub use rxrust::{Duration, Instant};
 
 /// Frame ticker emit message when new frame need to draw.
-pub type FrameTicker = Subject<'static, FrameMsg, Infallible>;
+pub type FrameTicker = LocalSubject<'static, FrameMsg, Infallible>;
 
 /// Message emitted at different status of a frame.
 

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -6,8 +6,8 @@ pub use std::{
 };
 use std::{cell::RefCell, convert::Infallible};
 
-use ops::box_it::CloneableBoxOp;
 use ribir_algo::Sc;
+use rxrust::observable::boxed::LocalBoxedObservableClone;
 use widget_id::RenderQueryable;
 
 pub(crate) use crate::widget_tree::*;
@@ -201,7 +201,7 @@ impl<'w> Widget<'w> {
 
   /// Establish reactive dirtiness tracking
   pub fn dirty_on(
-    self, upstream: CloneableBoxOp<'static, ModifyInfo, Infallible>, dirty: DirtyPhase,
+    self, upstream: LocalBoxedObservableClone<'static, ModifyInfo, Infallible>, dirty: DirtyPhase,
   ) -> Self {
     let track = TrackWidgetId::default();
     let id = track.track_id();

--- a/core/src/widget_tree/widget_id.rs
+++ b/core/src/widget_tree/widget_id.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use indextree::{Node, NodeId};
 use smallvec::{SmallVec, smallvec};
 
@@ -155,7 +153,7 @@ impl WidgetId {
     // another node,so we need check it manually.
     assert!(!self.is_dropped(tree));
 
-    let last_elem = Rc::new(RefCell::new(self));
+    let last_elem = Sc::new(RefCell::new(self));
     let last_elem2 = last_elem.clone();
     self
       .0

--- a/examples/pomodoro/src/pomodoro.rs
+++ b/examples/pomodoro/src/pomodoro.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ribir::prelude::{ops::box_it::BoxOp, *};
+use ribir::prelude::*;
 use rodio::Sink;
 
 use crate::{audio, config::PomodoroConfig};
@@ -22,7 +22,7 @@ pub struct Pomodoro {
   #[declare(skip)]
   pub state: PomodoroState,
   #[declare(skip)]
-  pub running_guard: Option<SubscriptionGuard<BoxSubscription<'static>>>,
+  pub running_guard: Option<SubscriptionGuard<BoxedSubscription>>,
   #[declare(skip)]
   pub rounds: u32,
 
@@ -110,11 +110,11 @@ impl Pomodoro {
 
   pub fn run(this: &impl StateWriter<Value = Self>, update_interval: Duration) {
     let mut start = Instant::now();
-    let boxed: BoxOp<'_, usize, _> = interval(update_interval, AppCtx::scheduler()).box_it();
+    let boxed: LocalBoxedObservable<'_, usize, _> = Local::interval(update_interval).box_it();
 
     let this = this.clone_writer();
     let this2 = this.clone_writer();
-    let guard: SubscriptionGuard<BoxSubscription<'_>> = boxed
+    let guard: SubscriptionGuard<BoxedSubscription> = boxed
       .subscribe(move |_| {
         let state_changed = this.write().elapse(start.elapsed());
         if state_changed {

--- a/examples/todos/src/ui.rs
+++ b/examples/todos/src/ui.rs
@@ -177,7 +177,7 @@ where
         (Transform::translation(0., 64.), 0.),
       );
       // items not displayed until the stagger animation is started.
-      watch!($read(fly_in).is_running()).filter(|v| *v).first().subscribe(move |_| {
+      watch!($read(fly_in).is_running()).filter(|v| *v).take(1).subscribe(move |_| {
         *$write(item.opacity()) = 1.;
       });
     }
@@ -194,7 +194,7 @@ pub fn todos() -> Widget<'static> {
     let save_todos = todos.clone_reader();
     todos
       .modifies()
-      .debounce(Duration::from_secs(5), AppCtx::scheduler())
+      .debounce(Duration::from_secs(5))
       .subscribe(move |_| {
         if let Err(err) = save_todos.read().save() {
           log::error!("Save tasks failed: {}", err);

--- a/macros/src/watch_macro.rs
+++ b/macros/src/watch_macro.rs
@@ -97,7 +97,7 @@ impl ToTokens for Upstreams {
     if self.0.len() == 1 {
       let modify = Modifies(&self.0[0]);
       quote_spanned! { modify.expr().span() =>
-          observable::of(ModifyInfo::default()).merge(#modify)
+          Local::of(ModifyInfo::default()).merge(#modify)
       }
       .to_tokens(tokens);
     } else {
@@ -110,8 +110,8 @@ impl ToTokens for Upstreams {
         .span();
 
       quote_spanned! { first_span =>
-          observable::of(ModifyInfo::default())
-              .merge(observable::from_iter([#(#modifies_iter),*]).merge_all(usize::MAX))
+          Local::of(ModifyInfo::default())
+              .merge(Local::from_iter([#(#modifies_iter),*]).merge_all(usize::MAX))
       }
       .to_tokens(tokens);
     }

--- a/ribir/src/platform/macos.rs
+++ b/ribir/src/platform/macos.rs
@@ -13,8 +13,7 @@ use icrate::{
     *,
   },
 };
-use ribir_core::prelude::AppCtx;
-use rxrust::prelude::{ObservableExt, ObservableItem, interval};
+use ribir_core::prelude::*;
 use winit::keyboard::{KeyCode, ModifiersState};
 
 use crate::prelude::{App, AppEvent, HotkeyEvent};
@@ -108,7 +107,7 @@ pub fn register_platform_app_events_handlers() {
       if query_accessibility_permissions() {
         add_global_monitor_for_events_matching_mask_handler();
       } else {
-        let _ = interval(Duration::from_secs(5), AppCtx::scheduler())
+        let _wait_complete = Local::interval(Duration::from_secs(5))
           .take_while(|_| !query_accessibility_permissions())
           .on_complete(|| {
             add_global_monitor_for_events_matching_mask_handler();

--- a/themes/material/src/classes/input_cls.rs
+++ b/themes/material/src/classes/input_cls.rs
@@ -8,7 +8,7 @@ pub(super) fn init(classes: &mut Classes) {
     rdl! {
       let mut w = FatObj::new(w);
       let blink_interval = Duration::from_millis(500);
-      let u = interval(blink_interval, AppCtx::scheduler())
+      let u = Local::interval(blink_interval)
         .subscribe(move |idx| *$write(w.opacity()) = (idx % 2) as f32);
       let border = BuildCtx::color()
         .map(|color| Border::only_left(BorderSide::new(2., (*color).into())));

--- a/themes/material/src/classes/scrollbar_cls.rs
+++ b/themes/material/src/classes/scrollbar_cls.rs
@@ -75,12 +75,14 @@ fn style_track(w: Widget, is_hor: bool) -> Widget {
       *$write(w.opacity()) = 1.;
       *$write(w.visible()) = true;
       fade.take();
-      let u = observable::timer((), Duration::from_secs(3), AppCtx::scheduler())
-        .filter(move |_| !*$read(w.is_hovered()))
+      let u = Local::timer(Duration::from_secs(3))
         .subscribe(move |_| {
-          *$write(w.opacity()) = 0.;
-          *$write(w.visible()) = false;
-        }).unsubscribe_when_dropped();
+          if !*$read(w.is_hovered()) {
+            *$write(w.opacity()) = 0.;
+            *$write(w.visible()) = false;
+          }
+        })
+        .unsubscribe_when_dropped();
       fade = Some(u);
     };
 

--- a/themes/material/src/state_layer.rs
+++ b/themes/material/src/state_layer.rs
@@ -37,7 +37,7 @@ impl HoverLayer {
 
     let u = watch!(*$read(host.is_hovered()))
       // Delay hover effects to prevent displaying this layer while scrolling.
-      .throttle_time(Duration::from_millis(100), ThrottleEdge::tailing(), AppCtx::scheduler())
+      .throttle_time(Duration::from_millis(100), ThrottleEdge::trailing())
       .distinct_until_changed()
       .subscribe({
         let layer = layer.clone_writer();

--- a/widgets/src/list.rs
+++ b/widgets/src/list.rs
@@ -161,7 +161,7 @@ pub struct List {
   items: Vec<Stateful<ListItem>>,
   /// Handles single-select subscription cleanup
   #[declare(skip)]
-  subscriptions: Vec<BoxSubscription<'static>>,
+  subscriptions: Vec<BoxedSubscription>,
 }
 
 // Defines class names used for styling list widgets
@@ -672,7 +672,7 @@ impl List {
         .distinct_until_changed()
         .filter(|selected| *selected)
         .subscribe(move |_| this.write().on_item_select(idx));
-      subscriptions.push(BoxSubscription::new(u));
+      subscriptions.push(BoxedSubscription::new(u));
     });
   }
 

--- a/widgets/src/tabs.rs
+++ b/widgets/src/tabs.rs
@@ -220,9 +220,7 @@ impl<'c> ComposeChild<'c> for Tabs {
         }
         @Expanded {
           defer_alloc: true,
-          @pipe! {
-            panes[$read(this).active].clone()
-          }
+          @pipe! { panes[$read(this).active].clone() }
         }
       }
     }


### PR DESCRIPTION
## Purpose of this Pull Request

- Update `rxrust` dependency and migrate usage to `LocalBoxedObservable` and `Local` operators.
- Refactor `Pipe`, `PriorityObservable`, and `StateWatcher` to implement `CoreObservable`.
- Remove explicit scheduler arguments from time-based operators.
- Fix `tokio` local task execution in tests.


## Checklist Before Merging

Please ensure the following are completed before merging:
- [x] If this is linked to an issue, include the link in your description.
- [x] If you've made changes to the code or documentation, make sure these are updated in the `CHANGELOG.md` file.
- [x] If you've introduced any break changes, briefly describe them in the `Breaking` section of the `CHANGELOG.md` file.

## Additional Information

**The bot will replace `#pr` in `CHANGELOG.md` with your pull request number. If your branch is out of sync, use `git pull --rebase` to update it.**

If you're unsure about which branch to submit your Pull Request to, or when it will be released after being merged, please refer to our [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md).

If you're working on a widget and need help writing test cases, we have some macros that can assist you. Please refer to the [Ribir Dev Helper](https://docs.rs/ribir_dev_helper) documentation.