### PR TITLE
fix(cli): 🔧 replace deprecated gitignore crate with ignore to fix inf…

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -14,7 +14,7 @@ clap = {version = "4.5.4", features = ["cargo", "derive"] }
 anyhow = "1.0" 
 fs_extra = "1.3.0"
 notify-debouncer-mini = "0.6.0"
-gitignore = "1.0.8"
+ignore = "0.4"
 tauri-bundler = "2.7.*"
 tauri-utils = "2.8.*"
 serde_json.workspace = true

--- a/tools/cli/src/run_wasm.rs
+++ b/tools/cli/src/run_wasm.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser};
+use ignore::gitignore::Gitignore;
 use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer, notify::*};
 
 use crate::{
@@ -116,22 +117,32 @@ impl Wasm {
   fn auto_rebuild(&self) -> Debouncer<RecommendedWatcher> {
     let root_path = self.root_path().unwrap();
     let ignore_file = root_path.join(".gitignore");
+
+    // Build gitignore matcher using the `ignore` crate
+    // Gitignore::new() parses the .gitignore file and returns a matcher
+    // that resolves patterns relative to the gitignore file's parent directory.
+    let (gitignore, err) = Gitignore::new(&ignore_file);
+    if let Some(e) = err {
+      eprintln!("Warning: some gitignore patterns failed to parse: {}", e);
+    }
+
     let this = self.clone();
     let mut debouncer =
       new_debouncer(WATCH_DEBOUNCE_GAP, move |res: DebounceEventResult| match res {
         Ok(events) => {
-          let ignore = gitignore::File::new(Path::new(&ignore_file));
           let need_rebuild = events.iter().any(|e| {
-            if let Ok(ignore) = &ignore {
-              return !ignore.is_excluded(&e.path).unwrap_or(false);
-            }
-            true
+            // Use matched_path_or_any_parents because `/target/` pattern only
+            // matches the directory itself, not files within it. This method
+            // walks up parent directories to check if any ancestor is ignored.
+            !gitignore
+              .matched_path_or_any_parents(&e.path, false)
+              .is_ignore()
           });
           if need_rebuild {
             let _ = this.wasm_build();
           }
         }
-        Err(e) => println!("Error {:?}", e),
+        Err(e) => eprintln!("Watch error: {:?}", e),
       })
       .unwrap();
 


### PR DESCRIPTION
…inite rebuild loop

The deprecated  crate (v1.0.8) did not correctly parse directory patterns like , causing all files under to trigger rebuilds and creating an infinite compilation loop in.

## Summary
<!-- 
Please explain:
1. Why is this change needed? (Context/Problem)
2. What does this change do? (Solution)

If this fixes an issue, use: Closes #123 
-->

<!-- RIBIR_SUMMARY_START -->

**Context**: The `gitignore` crate incorrectly parsed directory patterns like `/target/`, leading to infinite rebuild loops in the CLI's auto-rebuild mode.
**Changes**:
- Replaced the deprecated `gitignore` crate with the `ignore` crate in `tools/cli`.
- Migrated the rebuild logic to use `matched_path_or_any_parents` for robust ignore pattern matching.
- Improved error reporting by switching to `eprintln!` and adding warnings for failed pattern parsing.

<!-- RIBIR_SUMMARY_END -->

## Changelog

<!-- These entries will be collected into release notes. Changelog entries are for external users, not internal technical context. -->

<!-- RIBIR_CHANGELOG_START -->

- fix(cli): replace deprecated gitignore crate with ignore to fix infinite rebuild loop

<!-- RIBIR_CHANGELOG_END -->

## Notes for Reviewers (Optional)
<!--
Help reviewers understand your code:
- Key design decisions
- Any potential side effects or risks
-->

*Leave blank if not applicable.*



<details>
<summary>🌐 WASM Preview (for UI changes)</summary>

> 🚧 Coming soon: A bot will generate a WASM preview link when enabled.

- [ ] Generate WASM preview
- Example path: `examples/counter`

</details>

---

> **Tip:** Run `cargo +nightly ci` locally to pre-verify your changes.

<details>
<summary>📚 Resources</summary>

- [Contributing Guide](https://github.com/RibirX/Ribir/blob/master/CONTRIBUTING.md)
- [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md)

</details>

<details>
<summary>💡 Ribir Bot Commands</summary>

You can control the bot via comments:

```
@ribir-bot pr-fill             # Auto-fill placeholders
@ribir-bot pr-regen [context]  # Regenerate summary and changelog
@ribir-bot pr-summary [context] # Regenerate only the summary
@ribir-bot pr-entry [context]  # Regenerate only the changelog
@ribir-bot help                # Show all available commands
```

</details>
