### PR TITLE
fix(pipe): 🐛 use throttle for frame ticks and accumulate multiple change effects

### DIFF
--- a/core/src/builtin_widgets/class.rs
+++ b/core/src/builtin_widgets/class.rs
@@ -518,12 +518,17 @@ fn attach_outer_stream_subscription(
   let stream = pipe!($read(stream_writer).class.current())
     .with_effect(ModifyEffect::FRAMEWORK)
     .into_observable();
-  let sampler = BuildCtx::get()
-    .window()
-    .frame_tick_stream()
-    .filter(|msg| matches!(msg, FrameMsg::NewFrame(_)));
+  let wnd = BuildCtx::get().window();
   let u = stream
-    .sample(sampler)
+    .throttle(
+      move |_| {
+        wnd
+          .frame_tick_stream()
+          .filter_map(|msg| matches!(msg, FrameMsg::NewFrame(_)).then_some(()))
+          .take(1)
+      },
+      ThrottleEdge::trailing(),
+    )
     .subscribe(move |_| {
       runtime.refresh_from_state(&callback_writer, &manager);
     })
@@ -713,12 +718,17 @@ where
   ) -> SubscriptionGuard<BoxedSubscription> {
     let wnd = AppCtx::get_window(self.wnd_id)
       .expect("This handle is not valid because the window is closed");
-    let sampler = wnd
-      .frame_tick_stream()
-      .filter(|msg| matches!(msg, FrameMsg::NewFrame(_)));
     let manager = self.clone();
     stream
-      .sample(sampler)
+      .throttle(
+        move |_| {
+          wnd
+            .frame_tick_stream()
+            .filter_map(|msg| matches!(msg, FrameMsg::NewFrame(_)).then_some(()))
+            .take(1)
+        },
+        ThrottleEdge::trailing(),
+      )
       .subscribe(move |current| {
         manager.update(current, &apply);
       })
@@ -1181,6 +1191,42 @@ mod tests {
     *w_cls.write() = MARGIN;
     wnd.draw_frame();
     wnd.assert_root_size(Size::splat(120.));
+  }
+
+  #[test]
+  fn pipe_class_flushes_last_async_modify_before_source_complete() {
+    reset_test_env!();
+
+    class_names!(ASYNC_CLASS_A, ASYNC_CLASS_B);
+
+    let mut classes = initd_classes();
+    classes.insert(ASYNC_CLASS_A, style_class! { margin: EdgeInsets::all(1.) });
+    classes.insert(ASYNC_CLASS_B, style_class! { margin: EdgeInsets::all(2.) });
+
+    let source = Stateful::new(Some(ASYNC_CLASS_A));
+    let async_writer = source.clone_writer();
+
+    let wnd = TestWindow::from_widget(fn_widget! {
+      let classes = classes.clone();
+      @Providers {
+        providers: smallvec![classes.into_provider()],
+        @Container {
+          hint_size: Size::new(100., 100.),
+          class: class_list![pipe!(*$read(source))],
+        }
+      }
+    });
+
+    wnd.draw_frame();
+    wnd.assert_root_size(Size::new(102., 102.));
+
+    AppCtx::spawn_local(async move {
+      *async_writer.write() = Some(ASYNC_CLASS_B);
+    });
+    AppCtx::run_until_stalled();
+
+    wnd.draw_frame();
+    wnd.assert_root_size(Size::new(104., 104.));
   }
 
   #[test]

--- a/core/src/pipe.rs
+++ b/core/src/pipe.rs
@@ -1,12 +1,13 @@
 use std::{
-  cell::{RefCell, UnsafeCell},
+  cell::{Cell, RefCell, UnsafeCell},
   convert::Infallible,
 };
 
 use ribir_algo::Rc;
 use rxrust::{
   context::LocalCtx,
-  observable::boxed::LocalBoxedObservable,
+  observable::{CoreObservable, ObservableType, boxed::LocalBoxedObservable},
+  observer::Observer,
   scheduler::LocalScheduler,
   subscription::{BoxedSubscription, IntoBoxedSubscription},
 };
@@ -34,10 +35,10 @@ impl<V: 'static> Pipe<V> {
   ///
   /// # Parameters
   /// - `trigger`: Observable stream of modification scopes
-  /// - `map_handler`: Function converting ModifyScope to output values
+  /// - `map_handler`: Function converting ModifyEffect to output values
   pub fn new(
     trigger: LocalBoxedObservable<'static, ModifyInfo, Infallible>,
-    map_handler: impl FnMut(ModifyInfo) -> V + 'static,
+    map_handler: impl FnMut(ModifyEffect) -> V + 'static,
   ) -> Self {
     let info = SubscribeInfo { effect: ModifyEffect::DATA, priority: None };
     let info: Rc<RefCell<SubscribeInfo>> = Rc::new(RefCell::new(info));
@@ -638,11 +639,11 @@ struct PipeWidgetContextObserver<O> {
   wnd: Rc<Window>,
 }
 
-impl<O> Observer<ModifyInfo, Infallible> for PipeWidgetContextObserver<O>
+impl<O> Observer<ModifyEffect, Infallible> for PipeWidgetContextObserver<O>
 where
-  O: Observer<ModifyInfo, Infallible>,
+  O: Observer<ModifyEffect, Infallible>,
 {
-  fn next(&mut self, value: ModifyInfo) {
+  fn next(&mut self, value: ModifyEffect) {
     let wid = self.pipe_node.dyn_info().host_id();
 
     // Initialize the build context for the duration of the observer callback.
@@ -664,7 +665,7 @@ where
 
 impl ObservableType for PipeOp {
   type Item<'a>
-    = ModifyInfo
+    = ModifyEffect
   where
     Self: 'a;
 
@@ -673,7 +674,7 @@ impl ObservableType for PipeOp {
 
 impl<O> CoreObservable<LocalCtx<O, LocalScheduler>> for PipeOp
 where
-  O: Observer<ModifyInfo, Infallible> + 'static,
+  O: Observer<ModifyEffect, Infallible> + 'static,
 {
   type Unsub = BoxedSubscription;
 
@@ -684,22 +685,45 @@ where
     let scope = info.effect;
     let priority = info.priority.take();
 
-    let source = self.source.filter(move |s| s.contains(scope));
-
     if let Some(priority) = priority {
       let pipe_node = priority.node.clone();
       let wnd = priority.wnd.clone();
+      let observer = PipeWidgetContextObserver { observer, pipe_node, wnd: wnd.clone() };
+      let pending = Rc::new(Cell::new(ModifyEffect::empty()));
 
-      let sampler = wnd
-        .frame_tick_stream()
-        .filter_map(|msg| matches!(msg, FrameMsg::NewFrame(_)).then_some(()))
-        .merge(Local::of(()));
+      let stream = self
+        .source
+        .map({
+          let pending = pending.clone();
+          move |value| {
+            pending.set(pending.get() | value.effect);
+          }
+        })
+        .throttle(
+          move |_| {
+            wnd
+              .frame_tick_stream()
+              .filter_map(|msg| matches!(msg, FrameMsg::NewFrame(_)).then_some(()))
+              .take(1)
+          },
+          ThrottleEdge::trailing(),
+        )
+        .merge(Local::of(()))
+        .filter_map(move |_| {
+          let effect = pending.replace(ModifyEffect::empty());
+          (!effect.is_empty()).then_some(effect)
+        })
+        .filter(move |s| s.contains(scope))
+        .priority(priority)
+        .box_it();
 
-      let stream = source.sample(sampler).priority(priority);
-      let observer = PipeWidgetContextObserver { observer, pipe_node, wnd };
       stream.subscribe_with(observer).into_boxed()
     } else {
-      source.subscribe_with(observer).into_boxed()
+      self
+        .source
+        .filter_map(move |s| s.effect.contains(scope).then_some(s.effect))
+        .subscribe_with(observer)
+        .into_boxed()
     }
   }
 }
@@ -1211,5 +1235,31 @@ mod tests {
     // refreshing the child widget of the pipe.
     *m_writer.write() += 1;
     wnd.draw_frame();
+  }
+
+  #[test]
+  fn pipe_flushes_last_async_modify_before_source_complete() {
+    reset_test_env!();
+
+    let source = Stateful::new(Size::zero());
+    let async_writer = source.clone_writer();
+
+    let widget = fn_widget! {
+      pipe!(*$read(source)).map(|size| fn_widget! {
+        @MockBox { size }
+      })
+    };
+
+    let wnd = TestWindow::from_widget(widget);
+    wnd.draw_frame();
+    wnd.assert_root_size(Size::zero());
+
+    AppCtx::spawn_local(async move {
+      *async_writer.write() = Size::new(16., 9.);
+    });
+    AppCtx::run_until_stalled();
+
+    wnd.draw_frame();
+    wnd.assert_root_size(Size::new(16., 9.));
   }
 }

--- a/macros/src/distinct_pipe_macro.rs
+++ b/macros/src/distinct_pipe_macro.rs
@@ -6,7 +6,7 @@ use crate::{error::result_to_token_stream, symbol_process::*, watch_macro::*};
 
 pub fn gen_code(input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>) -> TokenStream {
   let span = input.span();
-  let res = process_watch_body(input, refs_ctx).map(|WatchBody { upstream, map_handler }| {
+  let res = process_pipe_body(input, refs_ctx).map(|WatchBody { upstream, map_handler }| {
     quote_spanned! {span =>
       Pipe::new(#upstream.box_it(), #map_handler)
         .transform(|s| s.distinct_until_changed())

--- a/macros/src/pipe_macro.rs
+++ b/macros/src/pipe_macro.rs
@@ -6,7 +6,7 @@ use crate::{error::result_to_token_stream, symbol_process::*, watch_macro::*};
 
 pub fn gen_code(input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>) -> TokenStream {
   let span = input.span();
-  let res = process_watch_body(input, refs_ctx).map(|WatchBody { upstream, map_handler }| {
+  let res = process_pipe_body(input, refs_ctx).map(|WatchBody { upstream, map_handler }| {
     quote_spanned! {span => Pipe::new(#upstream.box_it(), #map_handler) }
   });
   result_to_token_stream(res)

--- a/macros/src/watch_macro.rs
+++ b/macros/src/watch_macro.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote_spanned};
+use quote::{ToTokens, quote, quote_spanned};
 use smallvec::SmallVec;
 use syn::{
   Stmt,
@@ -37,8 +37,8 @@ impl BodyExpr {
 }
 
 /// Public interface for processing watch bodies with optional context
-pub fn process_watch_body(
-  input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>,
+fn process_body_with_arg_ty(
+  input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>, arg_ty: TokenStream,
 ) -> Result<WatchBody> {
   let span = input.span();
 
@@ -60,11 +60,23 @@ pub fn process_watch_body(
   } else {
     let map_handler = quote_spanned! { span => {
       #refs
-      move |_: ModifyInfo| { #(#expr)* }
+      move |_: #arg_ty| { #(#expr)* }
     }};
 
     Ok(WatchBody { upstream: Upstreams::new(refs), map_handler })
   }
+}
+
+pub fn process_watch_body(
+  input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>,
+) -> Result<WatchBody> {
+  process_body_with_arg_ty(input, refs_ctx, quote!(ModifyInfo))
+}
+
+pub fn process_pipe_body(
+  input: TokenStream, refs_ctx: Option<&mut DollarRefsCtx>,
+) -> Result<WatchBody> {
+  process_body_with_arg_ty(input, refs_ctx, quote!(ModifyEffect))
 }
 
 /// Generates final output code from processed watch body


### PR DESCRIPTION
Previously, two critical issues existed in the pipe sampling logic:
  - When the source writer completed (cnt=0), sample() would complete without emitting the final value, causing async modifications to be lost
  - Multiple rapid changes were being sampled independently, with only the last effect being preserved instead of accumulating all effects

## Summary
<!-- 
Please explain:
1. Why is this change needed? (Context/Problem)
2. What does this change do? (Solution)

If this fixes an issue, use: Closes #123 
-->

<!-- RIBIR_SUMMARY_START -->

**Context**: The pipe sampling logic was losing async modifications when the source writer completed and failed to accumulate multiple rapid changes.
**Changes**:
- Replaced `.sample()` with `.throttle()` in pipe and class widgets to ensure the final value is always emitted on the trailing edge.
- Updated pipe implementation to accumulate multiple `ModifyEffect` flags between frame ticks instead of overwriting them.
- Refactored `watch!`, `pipe!`, and `distinct_pipe!` macros to correctly handle different argument types for their internal closures.
- Added regression tests for async modification flushing before source completion.

<!-- RIBIR_SUMMARY_END -->

## Changelog

<!-- These entries will be collected into release notes. Changelog entries are for external users, not internal technical context. -->

<!-- RIBIR_CHANGELOG_START -->

- fix(core): ensure pipe emits final value on completion and accumulates multiple change effects

<!-- RIBIR_CHANGELOG_END -->

## Notes for Reviewers (Optional)
<!--
Help reviewers understand your code:
- Key design decisions
- Any potential side effects or risks
-->

*Leave blank if not applicable.*



<details>
<summary>🌐 WASM Preview (for UI changes)</summary>

> 🚧 Coming soon: A bot will generate a WASM preview link when enabled.

- [ ] Generate WASM preview
- Example path: `examples/counter`

</details>

---

> **Tip:** Run `cargo +nightly ci` locally to pre-verify your changes.

<details>
<summary>📚 Resources</summary>

- [Contributing Guide](https://github.com/RibirX/Ribir/blob/master/CONTRIBUTING.md)
- [Release Guide](https://github.com/RibirX/Ribir/blob/master/RELEASE.md)

</details>

<details>
<summary>💡 Ribir Bot Commands</summary>

You can control the bot via comments:

```
@ribir-bot pr-fill             # Auto-fill placeholders
@ribir-bot pr-regen [context]  # Regenerate summary and changelog
@ribir-bot pr-summary [context] # Regenerate only the summary
@ribir-bot pr-entry [context]  # Regenerate only the changelog
@ribir-bot help                # Show all available commands
```

</details>
